### PR TITLE
Require minimum faraday version

### DIFF
--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Slack Web and RealTime API client.'
   s.add_dependency 'activesupport'
-  s.add_dependency 'faraday'
+  s.add_dependency 'faraday', '>= 0.9'
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'json'
   s.add_dependency 'websocket-driver'


### PR DESCRIPTION
With Faraday `<= 0.8`, the following error will be thrown:

slack-ruby-client-0.7.0/lib/slack/web/api/error.rb:4:in `<module:Api>': superclass must be a Class (Module given) (TypeError)