### PR TITLE
Check for dead actors before termination

### DIFF
--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -39,7 +39,7 @@ module Slack
             logger.debug("#{self.class}##{__method__}") { e }
             driver.emit(:close, WebSocket::Driver::CloseEvent.new(1001, 'server closed connection')) unless @closing
           ensure
-            terminate
+            terminate if ::Celluloid::Actor.current.alive?
           end
 
           def close


### PR DESCRIPTION
Health of the actor is obtained using ` ::Celluloid::Actor.current.alive?`. 