### PR TITLE
add support for automated user invite

### DIFF
--- a/lib/slack/web/api/endpoints/users.rb
+++ b/lib/slack/web/api/endpoints/users.rb
@@ -75,6 +75,18 @@ module Slack
             throw ArgumentError.new('Required arguments :presence missing') if options[:presence].nil?
             post('users.setPresence', options)
           end
+
+          # This method lets you invite users to slack automatically.
+          #
+          # @ options requires email.
+          # This method is undocumented, but appears in tutorials for how to do this.
+          # @see https://levels.io/slack-typeform-auto-invite-sign-ups/
+
+          def users_invite(options = {})
+            throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+            post('users.admin.invite', options)
+
+          end
         end
       end
     end


### PR DESCRIPTION
There is an undocumented (well at least when I programmed it a few months back) method for automatically inviting users to slack via an api call with their email, which is very useful for support slack communities and corporate slack accounts.  

Let me know if there are any issues with this.  I finally just got around to committing this back to you, and thanks for this lovely ruby client.