### PR TITLE
Require minimum faraday version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#108](https://github.com/slack-ruby/slack-ruby-client/pull/108): Use slack-ruby-danger gem - [@dblock](https://github.com/dblock).
 * [#116](https://github.com/slack-ruby/slack-ruby-client/pull/116): Use [slack-ruby/slack-api-ref](https://github.com/slack-ruby/slack-api-ref) as machine API reference - [@dblock](https://github.com/dblock).
 * [#116](https://github.com/slack-ruby/slack-ruby-client/pull/116): Added `users_setPhoto` and `users_deletePhoto` to Web API - [@dblock](https://github.com/dblock).
+* [#81](https://github.com/slack-ruby/slack-ruby-client/pull/81): Require faraday 0.9.0 or newer - [@leppert](https://github.com/leppert).
 * Your contribution here.
 
 ### 0.7.7 (8/29/2016)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Slack Web and RealTime API client.'
   s.add_dependency 'activesupport'
-  s.add_dependency 'faraday'
+  s.add_dependency 'faraday', '>= 0.9'
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'json'
   s.add_dependency 'websocket-driver'


### PR DESCRIPTION
With Faraday `<= 0.8`, the following error will be thrown:

slack-ruby-client-0.7.0/lib/slack/web/api/error.rb:4:in `<module:Api>': superclass must be a Class (Module given) (TypeError)

Replaces https://github.com/slack-ruby/slack-ruby-client/pull/81.