### PR TITLE
Stop a duplicate definition warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#116](https://github.com/slack-ruby/slack-ruby-client/pull/116): Use [slack-ruby/slack-api-ref](https://github.com/slack-ruby/slack-api-ref) as machine API reference - [@dblock](https://github.com/dblock).
 * [#116](https://github.com/slack-ruby/slack-ruby-client/pull/116): Added `users_setPhoto` and `users_deletePhoto` to Web API - [@dblock](https://github.com/dblock).
 * [#81](https://github.com/slack-ruby/slack-ruby-client/pull/81): Require faraday 0.9.0 or newer - [@leppert](https://github.com/leppert).
+* [#123](https://github.com/slack-ruby/slack-ruby-client/pull/123): Fix a warning about duplicate definitions - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### 0.7.7 (8/29/2016)

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -15,8 +15,7 @@ module Slack
           BLOCK_SIZE = 4096
 
           extend ::Forwardable
-          def_delegator :socket, :write
-          def_delegators :driver, :text, :binary, :close
+          def_delegators :driver, :text, :binary
 
           attr_reader :socket
 


### PR DESCRIPTION
When running ruby with `RUBYOPT="-w"` or with RSpec running with
warnings turned on, these errors were being thrown:

```
slack-ruby-client/lib/slack/real_time/concurrency/celluloid.rb:45: warning: method redefined; discarding old close
ruby-2.3.1/lib/ruby/2.3.0/forwardable.rb:187: warning: previous definitionof close was here
slack-ruby-client/lib/slack/real_time/concurrency/celluloid.rb:61: warning: method redefined; discarding old write
ruby-2.3.1/lib/ruby/2.3.0/forwardable.rb:187: warning: previous definitionof write was here
```

This change removes the delegators that were present, since the wrappers
call them directly anyway.