### PR TITLE
Increase the default timeout for rtm.start to 180 seconds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### 0.8.0 (Next)
 
-* [#134](https://github.com/slack-ruby/slack-ruby-client/issues/134): Added `timeout` and `open_timeout` options to Web API - [@dblock](https://github.com/dblock).
+* [#135](https://github.com/slack-ruby/slack-ruby-client/issues/135): Added `timeout` and `open_timeout` options to Web API - [@dblock](https://github.com/dblock).
+* [#134](https://github.com/slack-ruby/slack-ruby-client/issues/134): Set `start_options[:request][:timeout]`, used with `rtm.start` in `Slack::RealTime::Client`, to 180 seconds - [@dblock](https://github.com/dblock).
+* [#136](https://github.com/slack-ruby/slack-ruby-client/pull/136): Pass request options in web client calls - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.7.9 (2/9/2017)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ logger       | Optional `Logger` instance that logs HTTP requests.
 timeout      | Optional open/read timeout in seconds.
 open_timeout | Optional connection open timeout in seconds.
 
+You can also pass request options, including `timeout` and `open_timeout` into individual calls.
+
+```ruby
+client.channels_list(request: { timeout: 180 })
+```
+
 ### RealTime Client
 
 The Real Time Messaging API is a WebSocket-based API that allows you to receive events from Slack in real time and send messages as user.
@@ -266,7 +272,7 @@ token           | Slack API token.
 websocket_ping  | The number of seconds that indicates how often the WebSocket should send ping frames, default is 30.
 websocket_proxy | Connect via proxy, include `:origin` and `:headers`.
 store_class     | Local store class name, default is an in-memory `Slack::RealTime::Stores::Store`.
-start_options   | Options to pass into `rtm.start`, default is `{}`.
+start_options   | Options to pass into `rtm.start`, default is `{ request: { timeout: 180 } }`.
 logger          | Optional `Logger` instance that logs RealTime requests and socket data.
 
 Note that the RealTime client uses a Web client to obtain the WebSocket URL via [rtm.start](https://api.slack.com/methods/rtm.start). While `token` and `logger` options are passed down from the RealTime client, you may also configure Web client options via `Slack::Web::Client.configure` as described above.
@@ -300,12 +306,16 @@ See a fully working example in [examples/hi_real_time_and_web](examples/hi_real_
 
 ### Large Team Considerations
 
-For large teams of thousands of members you may also want to increase the default web client timeout, since `rtm.start` downloads a large amount of data.
+The `rtm.start` call downloads a large amount of data. For large teams, consider reducing the amount of unnecessary data downloaded with `start_options`. You may also want to increase the default timeout of 180 seconds.
 
 ```ruby
-Slack::Web::Client.config do |config|
-  config.timeout = 5
-  config.open_timeout = 5
+Slack::RealTime::Client.config do |config|
+  # Return timestamp only for latest message object of each channel.
+  config.start_options[:simple_latest] = true
+  # Skip unread counts for each channel.
+  config.start_options[:no_unreads] = true
+  # Increase request timeout to 6 minutes.
+  config.start_options[:request][:timeout] = 360
 end
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,28 @@
 Upgrading Slack-Ruby-Client
 ===========================
 
+### Upgrading to >= 0.8.0
+
+The default timeout for `rtm.start` has been increased from 60 to 180 seconds via `Slack::RealTime::Client.config.start_options[:request][:timeout]`. If you're explicitly setting `start_options` in your application, preserve the value by merging settings instead of replacing the entire `start_options` value.
+
+Before:
+
+```ruby
+Slack::RealTime::Client.config do |config|
+  config.start_options = { no_unreads: true }
+end
+```
+
+After:
+
+```ruby
+Slack::RealTime::Client.config do |config|
+  config.start_options[:no_unreads] = true # keeps config.start_options[:request] intact
+end
+```
+
+See [#136](https://github.com/slack-ruby/slack-ruby-client/pull/136) for more details.
+
 ### Upgrading to >= 0.6.0
 
 #### Changes to API Response Data

--- a/lib/slack/real_time/config.rb
+++ b/lib/slack/real_time/config.rb
@@ -22,7 +22,7 @@ module Slack
         self.websocket_proxy = nil
         self.token = nil
         self.concurrency = method(:detect_concurrency)
-        self.start_options = {}
+        self.start_options = { request: { timeout: 180 } }
         self.store_class = Slack::RealTime::Store
         self.logger = nil
       end

--- a/lib/slack/web/faraday/request.rb
+++ b/lib/slack/web/faraday/request.rb
@@ -30,6 +30,7 @@ module Slack
               request.path = path
               request.body = options unless options.empty?
             end
+            request.options.merge!(options.delete(:request)) if options.key?(:request)
           end
           response.body
         end

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Slack::RealTime::Client, vcr: { cassette_name: 'web/rtm_start' } 
           client.start!
         end
         it 'sets start_options' do
-          expect(client.start_options).to eq({})
+          expect(client.start_options).to eq(request: { timeout: 180 })
         end
       end
     end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -4,6 +4,6 @@ require 'webmock/rspec'
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/slack'
   config.hook_into :webmock
-  config.default_cassette_options = { record: :new_episodes }
+  # config.default_cassette_options = { record: :new_episodes }
   config.configure_rspec_metadata!
 end


### PR DESCRIPTION
Closes #134.