### PR TITLE
CI against Ruby 2.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,28 @@ language: ruby
 
 cache: bundler
 
+rvm:
+  - 2.2
+  - 2.1
+  - 2.0
+  - rbx-2
+  - jruby-19mode
+  - ruby-head
+  - jruby-head
+
 matrix:
   include:
-    - rvm: 2.3.1
+    - rvm: 2.4.1
       script:
         - bundle exec danger
-    - rvm: 2.3.1
+    - rvm: 2.4.1
       env: CONCURRENCY=celluloid-io
-    - rvm: 2.3.1
+    - rvm: 2.4.1
       env: CONCURRENCY=faye-websocket
-    - rvm: 2.2
-    - rvm: 2.1
-    - rvm: 2.0
-    - rvm: rbx-2
-    - rvm: jruby-19mode
-    - rvm: ruby-head
-    - rvm: jruby-head
+    - rvm: 2.3.4
+      env: CONCURRENCY=celluloid-io
+    - rvm: 2.3.4
+      env: CONCURRENCY=faye-websocket
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head


### PR DESCRIPTION
Ruby 2.4.1 released
Ref https://www.ruby-lang.org/en/news/2017/03/22/ruby-2-4-1-released/