### PR TITLE
Gracefully close websocket on Errno::EPIPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.9.2 (Next)
 
 * [#161](https://github.com/slack-ruby/slack-ruby-client/pull/161): Added support for cursor pagination - [@dblock](https://github.com/dblock).
+* [#162](https://github.com/slack-ruby/slack-ruby-client/pull/162): Gracefully close websocket on errno::epipe - [@johanoskarsson](https://github.com/johanoskarsson).
 * Your contribution here.
 
 ### 0.9.1 (8/24/2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.9.2 (Next)
 
 * [#161](https://github.com/slack-ruby/slack-ruby-client/pull/161): Added support for cursor pagination - [@dblock](https://github.com/dblock).
-* [#162](https://github.com/slack-ruby/slack-ruby-client/pull/162): Gracefully close websocket on errno::epipe - [@johanoskarsson](https://github.com/johanoskarsson).
+* [#162](https://github.com/slack-ruby/slack-ruby-client/pull/162): Gracefully close websocket on Errno::EPIPE - [@johanoskarsson](https://github.com/johanoskarsson).
 * Your contribution here.
 
 ### 0.9.1 (8/24/2017)

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -34,7 +34,7 @@ module Slack
             @connected = @socket.connect
             driver.start
             loop { read } if socket
-          rescue EOFError => e
+          rescue EOFError, SystemCallError => e
             logger.debug("#{self.class}##{__method__}") { e }
             driver.emit(:close, WebSocket::Driver::CloseEvent.new(1001, 'server closed connection')) unless @closing
           ensure

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -34,7 +34,7 @@ module Slack
             @connected = @socket.connect
             driver.start
             loop { read } if socket
-          rescue EOFError, SystemCallError => e
+          rescue EOFError, Errno::EPIPE => e
             logger.debug("#{self.class}##{__method__}") { e }
             driver.emit(:close, WebSocket::Driver::CloseEvent.new(1001, 'server closed connection')) unless @closing
           ensure

--- a/spec/slack/real_time/concurrency/celluloid_spec.rb
+++ b/spec/slack/real_time/concurrency/celluloid_spec.rb
@@ -43,6 +43,22 @@ begin
             socket.run_loop
           end
         end
+
+        describe '#run_loop with epipe' do
+          let(:test_socket) do
+            Class.new(described_class) do
+              def read
+                fail Errno::EPIPE
+              end
+            end
+          end
+
+          it 'runs' do
+            expect(ws).to receive(:emit)
+            expect(ws).to receive(:start)
+            socket.run_loop
+          end
+        end
       end
 
       pending 'send_data'


### PR DESCRIPTION
I kept running into the following error:
E, [2017-09-05T14:23:29.153409 #10948] ERROR -- : Actor crashed!
Errno::EPIPE: Broken pipe
        /usr/share/rvm/rubies/ruby-2.3.4/lib/ruby/2.3.0/openssl/buffering.rb:379:in `syswrite_nonblock'

This would crash my bot entirely. By catching Errno::EPIPE and gracefully closing (and later reconnecting) the error has gone away. I have not done any deeper digging into this issue, but in case others run into it this worked for me. 