### PR TITLE
Fix logging errors in real-time component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.9.2 (Next)
 
 * [#161](https://github.com/slack-ruby/slack-ruby-client/pull/161): Added support for cursor pagination - [@dblock](https://github.com/dblock).
+* [#163](https://github.com/slack-ruby/slack-ruby-client/pull/163): Fix UTF8 logging errors in real-time Celluloid component - [@rfwatson](https://github.com/rfwatson).
 * Your contribution here.
 
 ### 0.9.1 (8/24/2017)

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -53,12 +53,12 @@ module Slack
           end
 
           def handle_read(buffer)
-            logger.debug("#{self.class}##{__method__}") { buffer }
+            logger.debug("#{self.class}##{__method__}") { buffer.force_encoding('UTF-8') }
             driver.parse buffer
           end
 
           def write(data)
-            logger.debug("#{self.class}##{__method__}") { data }
+            logger.debug("#{self.class}##{__method__}") { data.force_encoding('UTF-8') }
             socket.write(data)
           end
 


### PR DESCRIPTION
Avoids `log writing failed. "\x81 from ASCII-8BIT to UTF8"`