### PR TITLE
Use rtm.start when store is set to any subclass of Slack::RealTime::Stores::Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#163](https://github.com/slack-ruby/slack-ruby-client/pull/164): Use `OpenSSL::X509::DEFAULT_CERT_DIR` and `OpenSSL::X509::DEFAULT_CERT_FILE` for default ca_cert and ca_file - [@leifcr](https://github.com/leifcr).
 * [#161](https://github.com/slack-ruby/slack-ruby-client/pull/161): Added support for cursor pagination - [@dblock](https://github.com/dblock).
 * [#162](https://github.com/slack-ruby/slack-ruby-client/pull/162): Gracefully close websocket on `Errno::EPIPE` - [@johanoskarsson](https://github.com/johanoskarsson).
+* [#172](https://github.com/slack-ruby/slack-ruby-client/pull/172): Use `rtm.start` when store is a subclass of `Slack::RealTime::Stores::Store` (default) - [@kstole](https://github.com/kstole).
 * Your contribution here.
 
 ### 0.9.1 (8/24/2017)

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -117,7 +117,7 @@ module Slack
       def rtm_start_method
         if start_method
           start_method
-        elsif @store_class == Slack::RealTime::Stores::Store
+        elsif @store_class && @store_class <= Slack::RealTime::Stores::Store
           :rtm_start
         else
           :rtm_connect


### PR DESCRIPTION
Currently, the default `store_class` is `Slack::RealTime::Store`, but `rtm_start_method` checks for `Slack::RealTime::Stores::Store` when selecting `:rtm_start`. This change allows subclasses to also use `:rtm_start`.