### PR TITLE
Concatenate error message when multiple errors present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.11.1 (Next)
 
+* [#187](https://github.com/slack-ruby/slack-ruby-client/pull/187): Concatenate error message when multiple errors present - [@chrislopresto](https://github.com/chrislopresto).
 * Your contribution here.
 
 ### 0.11.0 (11/25/2017)

--- a/lib/slack/web/faraday/response/raise_error.rb
+++ b/lib/slack/web/faraday/response/raise_error.rb
@@ -9,7 +9,8 @@ module Slack
             elsif (body = env.body) && body['ok']
               nil
             else
-              raise Slack::Web::Api::Errors::SlackError.new(body['error'], env.response)
+              error_message = body['error'] || body['errors'].map { |message| message['error'] }.join(',')
+              raise Slack::Web::Api::Errors::SlackError.new(error_message, env.response)
             end
           end
         end

--- a/spec/slack/web/faraday/response/raise_error_spec.rb
+++ b/spec/slack/web/faraday/response/raise_error_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe Slack::Web::Faraday::Response::RaiseError do
+  describe '#on_complete' do
+    let(:subject) { described_class.new }
+    let(:status) { 200 }
+    let(:response) { nil }
+    let(:body) { {} }
+    let(:env) { double status: status, response: response, body: body }
+
+    context 'with status of 429' do
+      let(:status) { 429 }
+
+      it 'raises a TooManyRequestsError' do
+        expect { subject.on_complete(env) }.to raise_error(Slack::Web::Api::Errors::TooManyRequestsError)
+      end
+    end
+
+    context 'with an ok payload in the body' do
+      let(:body) { { 'ok' => 'true' } }
+
+      it 'is nil' do
+        expect(subject.on_complete(env)).to eq nil
+      end
+    end
+
+    context 'with a single error in the body' do
+      let(:body) { { 'error' => 'already_in_channel' } }
+
+      it 'raises a SlackError with the error message' do
+        expect { subject.on_complete(env) }.to raise_error(Slack::Web::Api::Errors::SlackError, 'already_in_channel')
+      end
+    end
+
+    context 'with multiple errors in the body' do
+      let(:body) do
+        {
+          'errors' => [
+            { 'error' => 'already_in_channel' },
+            { 'error' => 'something_else_terrible' }
+          ]
+        }
+      end
+
+      it 'raises a SlackError with the concatenated error messages' do
+        expect { subject.on_complete(env) }.to raise_error(Slack::Web::Api::Errors::SlackError, 'already_in_channel,something_else_terrible')
+      end
+    end
+  end
+end


### PR DESCRIPTION
In the else clause of the `Faraday::Response::RaiseError#on_complete ` method, we expect that the body object will have an `'error'` key. However, sometimes a response will have an `'errors'` key (plural) that contains a collection of error responses. 

I encountered this when making calls to `client.conversations_invite` with multiple users:

```sh
> client.conversations_invite users: [paul.slack_user_id, ringo.slack_user_id].join(','), channel: '#project-beatles'
----------------
Printing body.inspect to console
#<Slack::Messages::Message errors=#<Hashie::Array [#<Slack::Messages::Message error="already_in_channel" ok=false user="xxxxxxxxx">, #<Slack::Messages::Message error="already_in_channel" ok=false user="xxxxxxxxx">]> ok=false>
----------------
Slack::Web::Api::Errors::SlackError: Slack::Web::Api::Errors::SlackError
from /Users/chrislopresto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/slack-ruby-client-0.11.0/lib/slack/web/faraday/response/raise_error.rb:18:in `on_complete'
```

As a result, we don't pass up any helpful error message.

I'm not sure what the desired behavior should be when there are multiple errors. The tweak in this PR just concatenates an error message. So the results of the same call would now be:

```sh
> client.conversations_invite users: [paul.slack_user_id, george.slack_user_id].join(','), channel: '#project-beatles'
Slack::Web::Api::Errors::SlackError: already_in_channel,already_in_channel
from /Users/chrislopresto/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/slack-ruby-client-0.11.0/lib/slack/web/faraday/response/raise_error.rb:13:in `on_complete'
```

Let me know if this makes sense, if you want prefer another approach, if we should add a spec, etc.