### PR TITLE
Fix NoMethodError when Slack is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.11.1 (Next)
 
 * [#187](https://github.com/slack-ruby/slack-ruby-client/pull/187): Concatenate error message when multiple errors present - [@chrislopresto](https://github.com/chrislopresto).
+* [#188](https://github.com/slack-ruby/slack-ruby-client/pull/188): Fixed `NoMethodError` when Slack is unavailable - [@sonicdoe](https://github.com/sonicdoe).
 * Your contribution here.
 
 ### 0.11.0 (11/25/2017)

--- a/lib/slack/web/faraday/response/raise_error.rb
+++ b/lib/slack/web/faraday/response/raise_error.rb
@@ -6,9 +6,7 @@ module Slack
           def on_complete(env)
             if env.status == 429
               raise Slack::Web::Api::Errors::TooManyRequestsError, env.response
-            elsif (body = env.body) && body['ok']
-              nil
-            else
+            elsif (body = env.body) && !body['ok']
               error_message = body['error'] || body['errors'].map { |message| message['error'] }.join(',')
               raise Slack::Web::Api::Errors::SlackError.new(error_message, env.response)
             end

--- a/spec/fixtures/slack/web/503_error.yml
+++ b/spec/fixtures/slack/web/503_error.yml
@@ -1,0 +1,14 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://slack.com/api/auth.test
+  response:
+    status:
+      code: 503
+      message: Service Unavailable
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version:
+  recorded_at: Thu, 30 Nov 2017 14:36:26 GMT

--- a/spec/slack/web/api/errors/service_unavailable_spec.rb
+++ b/spec/slack/web/api/errors/service_unavailable_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Slack::Web::Client do
+  let(:client) { Slack::Web::Client.new }
+  it 'raises a Faraday::ClientError when Slack is unavailable', vcr: { cassette_name: 'web/503_error' } do
+    begin
+      client.auth_test
+      raise 'Expected to receive Faraday::ClientError.'
+    rescue Faraday::ClientError => e
+      expect(e.response).to_not be_nil
+      expect(e.response[:status]).to eq 503
+    end
+  end
+end


### PR DESCRIPTION
When Slack is experiencing connectivity issues and returns a `503 Service Unavailable`, slack-ruby-client should throw a `Faraday::ClientError`. However, due to https://github.com/slack-ruby/slack-ruby-client/blob/ffe7ec87ef74d99d2f162b05c976dc604d3aeb99/lib/slack/web/faraday/response/raise_error.rb#L12 a ``NoMethodError: undefined method `[]' for nil:NilClass`` is raised (since `body` is `nil`). The same error was also reported in https://github.com/slack-ruby/slack-ruby-client/issues/32.

I haven’t looked into an actual fix yet but [I figured](https://twitter.com/sindresorhus/status/579306280495357953) submitting a failing test would help 🙂