### PR TITLE
Adds http_proxy caveat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.11.1 (Next)
 
+* [#192](https://github.com/slack-ruby/slack-ruby-client/pull/192): Adds http_proxy caveat to README - [@phantomdata](https://github.com/phantomdata).
 * [#187](https://github.com/slack-ruby/slack-ruby-client/pull/187): Concatenate error message when multiple errors present - [@chrislopresto](https://github.com/chrislopresto).
 * [#188](https://github.com/slack-ruby/slack-ruby-client/pull/188): Fixed `NoMethodError` when Slack is unavailable - [@sonicdoe](https://github.com/sonicdoe).
 * Your contribution here.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ You can also pass request options, including `timeout` and `open_timeout` into i
 client.channels_list(request: { timeout: 180 })
 ```
 
+Note that the `http_proxy` environment variable will also be consulted and that Docker on OSX seems to incorrectly set that value, [causing `Faraday::ConnectionFailed`](https://github.com/slack-ruby/slack-ruby-bot/issues/155), `ERROR -- : Failed to open TCP connection to : (getaddrinfo: Name or service not known)`. You might need to manually unset `http_proxy` in that case, eg. `http_proxy="" bundle exec ruby ./my_bot.rb`.
+
 #### Pagination Support
 
 The Web client natively supports [cursor pagination](https://api.slack.com/docs/pagination#cursors) for methods that allow it, such as `users_list`. Supply a block and the client will make repeated requests adjusting the value of `cursor` with every response. The default limit is set to 100 and can be adjusted via `Slack::Web::Client.config.default_page_size` or by passing it directly into the API call.


### PR DESCRIPTION
Adds helpful caveat regarding Docker on OSX caveat and proxy usage to resolve https://github.com/slack-ruby/slack-ruby-client/issues/191.