### PR TITLE
Produce a warning when calling undocumented methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#187](https://github.com/slack-ruby/slack-ruby-client/pull/187): Concatenate error message when multiple errors present - [@chrislopresto](https://github.com/chrislopresto).
 * [#188](https://github.com/slack-ruby/slack-ruby-client/pull/188): Fixed `NoMethodError` when Slack is unavailable - [@sonicdoe](https://github.com/sonicdoe).
 * [#196](https://github.com/slack-ruby/slack-ruby-client/pull/196): Added `users_lookupByEmail` - [@manuelmeurer](https://github.com/manuelmeurer).
+* [#185](https://github.com/slack-ruby/slack-ruby-client/pull/185): Calling undocumented endpoints will now produce a warning - [@aviflombaum](https://github.com/aviflombaum).
 * Your contribution here.
 
 ### 0.11.0 (11/25/2017)

--- a/lib/slack/web/api/endpoints/channels.rb
+++ b/lib/slack/web/api/endpoints/channels.rb
@@ -41,6 +41,7 @@ module Slack
           def channels_delete(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
+            logger.warn('The channels.delete method is undocumented.')
             post('channels.delete', options)
           end
 

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -19,6 +19,7 @@ module Slack
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
             throw ArgumentError.new('Required arguments :command missing') if options[:command].nil?
             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
+            logger.warn('The chat.command method is undocumented.')
             post('chat.command', options)
           end
 

--- a/lib/slack/web/api/endpoints/files.rb
+++ b/lib/slack/web/api/endpoints/files.rb
@@ -30,6 +30,7 @@ module Slack
           def files_edit(options = {})
             throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
             throw ArgumentError.new('Required arguments :title missing') if options[:title].nil?
+            logger.warn('The files.edit method is undocumented.')
             post('files.edit', options)
           end
 
@@ -102,6 +103,7 @@ module Slack
             throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
+            logger.warn('The files.share method is undocumented.')
             post('files.share', options)
           end
 

--- a/lib/slack/web/api/endpoints/users_admin.rb
+++ b/lib/slack/web/api/endpoints/users_admin.rb
@@ -25,6 +25,7 @@ module Slack
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/users.admin/users.admin.invite.json
           def users_admin_invite(options = {})
             throw ArgumentError.new('Required arguments :email missing') if options[:email].nil?
+            logger.warn('The users.admin.invite method is undocumented.')
             post('users.admin.invite', options)
           end
 
@@ -37,6 +38,7 @@ module Slack
           def users_admin_setInactive(options = {})
             throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
+            logger.warn('The users.admin.setInactive method is undocumented.')
             post('users.admin.setInactive', options)
           end
         end

--- a/lib/slack/web/api/endpoints/users_prefs.rb
+++ b/lib/slack/web/api/endpoints/users_prefs.rb
@@ -10,6 +10,7 @@ module Slack
           #
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/users.prefs/users.prefs.get.json
           def users_prefs_get(options = {})
+            logger.warn('The users.prefs.get method is undocumented.')
             post('users.prefs.get', options)
           end
         end

--- a/lib/slack/web/api/templates/method.erb
+++ b/lib/slack/web/api/templates/method.erb
@@ -44,6 +44,9 @@ module Slack
 <% if data['args']['user'] %>
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
 <% end %>
+<% if data['undocumented'] %>
+            logger.warn('The <%= group %>.<%= name %> method is undocumented.')
+<% end %>
 <% if data['args'].keys.include?('cursor') %>
             if block_given?
               Pagination::Cursor.new(self, :<%= group.gsub(".", "_") %>_<%= name %>, options).each do |page|

--- a/spec/slack/web/client_spec.rb
+++ b/spec/slack/web/client_spec.rb
@@ -170,5 +170,13 @@ RSpec.describe Slack::Web::Client do
         expect(request.options.timeout).to eq 3
       end
     end
+    context 'calling undocumented methods' do
+      let(:client) { Slack::Web::Client.new }
+      it 'produces a warning' do
+        expect(client.logger).to receive(:warn).with('The users.admin.setInactive method is undocumented.')
+        expect(client).to receive(:post)
+        client.users_admin_setInactive(user: 'U092BDCLV')
+      end
+    end
   end
 end


### PR DESCRIPTION
Replaces https://github.com/slack-ruby/slack-ruby-client/pull/185