### PR TITLE
Improve error message if error response has resonse_metadata

### DIFF
--- a/lib/slack/web/faraday/response/raise_error.rb
+++ b/lib/slack/web/faraday/response/raise_error.rb
@@ -8,6 +8,9 @@ module Slack
               raise Slack::Web::Api::Errors::TooManyRequestsError, env.response
             elsif (body = env.body) && !body['ok']
               error_message = body['error'] || body['errors'].map { |message| message['error'] }.join(',')
+              if body.has_key?('response_metadata') && body['response_metadata'].has_key?('messages')
+                error_message << " Response Metadata: #{body['response_metadata']['messages'].join(',')}"
+              end
               raise Slack::Web::Api::Errors::SlackError.new(error_message, env.response)
             end
           end


### PR DESCRIPTION
Some slack errors responses such as `dialog.open` also contains `response_metadata` field with more useful information related to error. This PR will improve error message by showing that in client error message. 

Before
```
Slack::Web::Api::Errors::SlackError - validation_errors
```

After
```
2018-01-29 17:51:56 - Slack::Web::Api::Errors::SlackError - validation_errors Response Metadata: [ERROR] Element 0 field `label` cannot be longer than 24 characters:
```

https://api.slack.com/methods/dialog.open