### PR TITLE
Allow either attachments or text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ### 0.11.2 (Next)
 
 * Your contribution here.
+* [#209](https://github.com/slack-ruby/slack-ruby-client/pull/209): Changed `chat_postEphemeral`to check for existence of either `text` or `attachments` - [@peterzhu2118](https://github.com/peterzhu2118).
 * [#207](https://github.com/slack-ruby/slack-ruby-client/pull/207): Added `apps_permissions_resources_list` and `apps_permissions_scopes_list` - [@jmanian](https://github.com/jmanian).
 * [#207](https://github.com/slack-ruby/slack-ruby-client/pull/207): Added `users_conversations` - [@jmanian](https://github.com/jmanian).
 * [#206](https://github.com/slack-ruby/slack-ruby-client/pull/206): Fix 100% cpu usage in async examples - [@felixbuenemann](https://github.com/felixbuenemann).
 
-### 0.11.1 (1/23/2017)
+### 0.11.1 (1/23/2018)
 
 * [#187](https://github.com/slack-ruby/slack-ruby-client/pull/187): Concatenate error message when multiple errors present - [@chrislopresto](https://github.com/chrislopresto).
 * [#188](https://github.com/slack-ruby/slack-ruby-client/pull/188): Fixed `NoMethodError` when Slack is unavailable - [@sonicdoe](https://github.com/sonicdoe).

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -93,7 +93,7 @@ module Slack
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postEphemeral.json
           def chat_postEphemeral(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
+            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
             throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             # attachments must be passed as an encoded JSON string

--- a/lib/slack/web/api/patches/chat.5.postEphemeral-text-or-attachments.patch
+++ b/lib/slack/web/api/patches/chat.5.postEphemeral-text-or-attachments.patch
@@ -1,0 +1,13 @@
+diff --git a/slack-ruby-client/lib/slack/web/api/endpoints/chat.rb b/slack-ruby-client-original/lib/slack/web/api/endpoints/chat.rb
+index 194419e..2ef5c65 100644
+--- a/lib/slack/web/api/endpoints/chat.rb
++++ b/lib/slack/web/api/endpoints/chat.rb
+@@ -93,7 +93,7 @@ module Slack
+           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postEphemeral.json
+           def chat_postEphemeral(options = {})
+             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+-            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
++            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
+             throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
+             # attachments must be passed as an encoded JSON string

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
       client.chat_postEphemeral(channel: 'channel', text: 'text', user: '123', attachments: [])
     end
     context 'text and user arguments' do
-      it 'requires text' do
-        expect { client.chat_postEphemeral(channel: 'channel') }.to raise_error ArgumentError, /Required arguments :text missing/
+      it 'requires text or attachments' do
+        expect { client.chat_postEphemeral(channel: 'channel') }.to raise_error ArgumentError, /Required arguments :text or :attachments missing/
       end
       it 'requires user' do
         expect { client.chat_postEphemeral(channel: 'channel', text: 'text') }.to raise_error ArgumentError, /Required arguments :user missing/
@@ -34,6 +34,10 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
       it 'optional attachments' do
         expect(client).to receive(:post).with('chat.postEphemeral', hash_including(attachments: '[]'))
         expect { client.chat_postEphemeral(channel: 'channel', text: 'text', user: '123', attachments: []) }.to_not raise_error
+      end
+      it 'attachments without text' do
+        expect(client).to receive(:post).with('chat.postEphemeral', hash_including(attachments: '[]'))
+        expect { client.chat_postEphemeral(channel: 'channel', attachments: [], user: '123') }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
For `chat_postEphemeral`, either `text:` or `attachments:` is required, but the current code doesn't allow that (it checks that `text:` always exist).