### PR TITLE
Fix #198: Use a thread for Celluloid, shutdown EM.

### DIFF
--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -68,12 +68,9 @@ module Slack
           end
 
           def start_async(client)
-            @client = client
-            Actor.new(future.run_client_loop)
-          end
-
-          def run_client_loop
-            @client.run_loop
+            Thread.new do
+              client.run_loop
+            end
           end
 
           def connected?
@@ -81,18 +78,6 @@ module Slack
           end
 
           protected
-
-          class Actor
-            attr_reader :future
-
-            def initialize(future)
-              @future = future
-            end
-
-            def join
-              @future.value
-            end
-          end
 
           def build_socket
             socket = ::Celluloid::IO::TCPSocket.new(addr, port)

--- a/lib/slack/real_time/concurrency/eventmachine.rb
+++ b/lib/slack/real_time/concurrency/eventmachine.rb
@@ -27,11 +27,17 @@ module Slack
 
         class Socket < Slack::RealTime::Socket
           def start_async(client)
-            thread = ensure_reactor_running
+            @thread = ensure_reactor_running
 
             client.run_loop
 
-            thread
+            @thread
+          end
+
+          def close
+            super
+            EventMachine.stop if @thread
+            @thread = nil
           end
 
           def send_data(message)

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
 
   after do
     wait_for_server
+    connection.join
   end
 
   context 'client connected' do


### PR DESCRIPTION
Celluloid change is probably not the best as we create a thread per client now, but since it's going to be deprecated we can roll with it. Joining the actor from the integration spec didn't work.