### PR TITLE
Addressing a few issues with #run_ping! (Fixes #231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.13.2 (Next)
 
 * Your contribution here.
+* [#232](https://github.com/slack-ruby/slack-ruby-client/pull/232): Addressing a few issues with #run_ping! (fixes #231) - [@RodneyU215](https://github.com/RodneyU215).
 * [#226](https://github.com/slack-ruby/slack-ruby-client/pull/226): Added periodic ping that reconnects on failure for `async-websocket` - [@RodneyU215](https://github.com/RodneyU215), [@dblock](https://github.com/dblock), [@ioquatix](https://github.com/ioquatix).
 
 ### 0.13.1 (2018/9/30)

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -117,8 +117,9 @@ module Slack
         !websocket_ping.nil? && websocket_ping > 0
       end
 
+      protected
+
       def restart_async
-        return unless @socket
         @socket.close
         start = web_client.send(rtm_start_method, start_options)
         data = Slack::Messages::Message.new(start)
@@ -126,8 +127,6 @@ module Slack
         @store = @store_class.new(data) if @store_class
         @socket.restart_async(self, @url)
       end
-
-      protected
 
       # @return [Slack::RealTime::Socket]
       def build_socket

--- a/lib/slack/real_time/socket.rb
+++ b/lib/slack/real_time/socket.rb
@@ -63,6 +63,7 @@ module Slack
       end
 
       def time_since_last_message
+        return 0 unless @last_message_at
         current_time - @last_message_at
       end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -118,6 +118,18 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
     start_server
   end
 
+  # We currently only send regular pings when using 'async-websocket'. See Issue #223.
+  if ENV['CONCURRENCY'] == 'async-websocket'
+    it 'sends pings' do
+      client.websocket_ping = 2
+      client.on :pong do |data|
+        expect(data.reply_to).to be 1
+        client.stop!
+      end
+      start_server
+    end
+  end
+
   it 'gets close, followed by closed' do
     client.on :hello do
       expect(client.started?).to be true

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Slack::RealTime::Client do
       end
     end
   end
-  context 'client with a full store', vcr: { cassette_name: 'web/rtm_start' } do
+  context 'client with a full store', vcr: { cassette_name: 'web/rtm_start', allow_playback_repeats: true } do
     let(:client) { Slack::RealTime::Client.new(store_class: Slack::RealTime::Stores::Store) }
     let(:url) { 'wss://ms173.slack-msgs.com/websocket/lqcUiAvrKTP-uuid=' }
     describe '#start!' do
@@ -135,34 +135,18 @@ RSpec.describe Slack::RealTime::Client do
         allow(socket).to receive(:start_async)
         client.start_async
       end
-      describe '#run_ping' do
+      describe '#run_ping!' do
         it 'sends ping messages when the connection is idle' do
           allow(socket).to receive(:time_since_last_message).and_return(30)
           expect(socket).to receive(:send_data).with('{"type":"ping","id":1}')
-          client.run_ping
-        end
-        it 'disconnects the websocket when the connection is idle for too long' do
-          allow(socket).to receive(:time_since_last_message).and_return(75)
-          allow(socket).to receive(:connected?).and_return(false)
-
-          expect(socket).to receive(:disconnect!)
-          expect(socket).to receive(:close)
-          expect { client.run_ping }.to raise_error Slack::RealTime::Client::ClientNotStartedError
-        end
-      end
-      describe '#run_ping!' do
-        it 'returns if websocket_ping is less than 1' do
-          client.websocket_ping = 0
-          expect(client).to_not receive(:run_ping)
           client.run_ping!
         end
-        it 'reconnects the websocket if an exception is thrown' do
-          allow(socket).to receive(:time_since_last_message).and_return(75)
-          allow(socket).to receive(:disconnect!)
-          allow(socket).to receive(:close)
-          allow(socket).to receive(:connected?).and_return(false)
-
+        it 'reconnects the websocket if it has been idle for too long' do
+          allow(socket).to receive(:time_since_last_message).and_return(75, 31)
+          allow(socket).to receive(:connected?).and_return(true)
+          expect(socket).to receive(:close)
           expect(socket).to receive(:restart_async)
+          expect(socket).to receive(:send_data).with('{"type":"ping","id":1}')
           client.run_ping!
         end
       end


### PR DESCRIPTION

###  Summary
This PR addresses several issues with the initial implementation (#226) of `Slack::RealTime::Client#run_ping!`; a method which is responsible for ensuring the `Slack::RealTime::Client` stays connected until `Slack::RealTime::Client#stop!` is called.

- `Slack::RealTime::Client#close` will no longer assign nil to `@socket` because the reactor would still be running in the background if `websocket_ping` is set.
- `Slack::RealTime::Concurrency::Async::Socket#disconnect!` now cancels all timers (via `@reactor.cancel`). This shuts down the `websocket_ping` timer.
- I've removed the loop in `Slack::RealTime::Client#run_ping!` and now use on the builtin function `Async::Reactor#every` to run the ping on an interval.
- I've added `Slack::RealTime::Client#restart_sync` which is responsible for obtaining a new websocket url and attempting to connect to it.
- If the connection is closed and we've not called `Slack::RealTime::Client#stop!`; on the next `Slack::RealTime::Client#run_ping!` we'll attempt to restart the connection (via `Slack::RealTime::Client#restart_sync`)
- If we're still not connected, after attempting to restart the connection (via `Slack::RealTime::Client#restart_async`), we reraise `Slack::RealTime::Client::ClientNotStartedError`
- I've also added a new integration test to ensure it works as expected.

### Requirements
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slack-ruby/slack-ruby-client/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.