### PR TITLE
Removing the immediate retry to give the client time to reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.13.2 (Next)
 
 * Your contribution here.
+* [#234](https://github.com/slack-ruby/slack-ruby-client/pull/234): Removing the immediate retry to give the client time to reconnect - [@RodneyU215](https://github.com/RodneyU215).
 * [#232](https://github.com/slack-ruby/slack-ruby-client/pull/232): Addressing a few issues with #run_ping! (fixes #231) - [@RodneyU215](https://github.com/RodneyU215).
 * [#226](https://github.com/slack-ruby/slack-ruby-client/pull/226): Added periodic ping that reconnects on failure for `async-websocket` - [@RodneyU215](https://github.com/RodneyU215), [@dblock](https://github.com/dblock), [@ioquatix](https://github.com/ioquatix).
 

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -109,8 +109,6 @@ module Slack
         ping
       rescue Slack::RealTime::Client::ClientNotStartedError
         restart_async
-        retry if started?
-        raise
       end
 
       def run_ping?
@@ -120,6 +118,7 @@ module Slack
       protected
 
       def restart_async
+        logger.debug("#{self.class}##{__method__}")
         @socket.close
         start = web_client.send(rtm_start_method, start_options)
         data = Slack::Messages::Message.new(start)

--- a/lib/slack/real_time/concurrency/async.rb
+++ b/lib/slack/real_time/concurrency/async.rb
@@ -31,6 +31,7 @@ module Slack
 
           def restart_async(client, new_url)
             @url = new_url
+            @last_message_at = current_time
             return unless @reactor
             @reactor.async do
               client.run_loop

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -142,19 +142,11 @@ RSpec.describe Slack::RealTime::Client do
           client.run_ping!
         end
         it 'reconnects the websocket if it has been idle for too long' do
-          allow(socket).to receive(:time_since_last_message).and_return(75, 31)
+          allow(socket).to receive(:time_since_last_message).and_return(75)
           allow(socket).to receive(:connected?).and_return(true)
           expect(socket).to receive(:close)
           expect(socket).to receive(:restart_async)
-          expect(socket).to receive(:send_data).with('{"type":"ping","id":1}')
           client.run_ping!
-        end
-        it 'raises an exception if reconnect attempts fail' do
-          allow(socket).to receive(:time_since_last_message).and_return(75)
-          allow(socket).to receive(:close)
-          allow(socket).to receive(:restart_async)
-          allow(socket).to receive(:connected?).and_return(false)
-          expect { client.run_ping! }.to raise_error Slack::RealTime::Client::ClientNotStartedError
         end
       end
     end


### PR DESCRIPTION
### Summary
1. `#run_ping!` will no longer raise errors since it's no longer retrying the ping request. Instead the code will wait, until the reactor's timer, calls it again.
2. `#restart_async` will now reset `@last_message_at`, so that when the reactor's timer calls `#run_ping!` again, it will not raise an exception.

### Requirements
* [x] I've read and understood the [Contributing Guidelines](https://github.com/slack-ruby/slack-ruby-client/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.