### PR TITLE
handle nil attachments in a safe way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.13.2 (Next)
 
 * Your contribution here.
+* [#239](https://github.com/slack-ruby/slack-ruby-client/pull/239): Automatically replace `nil` attachments with safer equivalents - [@jmanian](https://github.com/jmanian).
 * [#234](https://github.com/slack-ruby/slack-ruby-client/pull/234): Removing the immediate retry to give the client time to reconnect - [@RodneyU215](https://github.com/RodneyU215).
 * [#232](https://github.com/slack-ruby/slack-ruby-client/pull/232): Addressing a few issues with #run_ping! (fixes #231) - [@RodneyU215](https://github.com/RodneyU215).
 * [#226](https://github.com/slack-ruby/slack-ruby-client/pull/226): Added periodic ping that reconnects on failure for `async-websocket` - [@RodneyU215](https://github.com/RodneyU215), [@dblock](https://github.com/dblock), [@ioquatix](https://github.com/ioquatix).

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -213,13 +213,10 @@ module Slack
             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
-              if options[:attachments].nil?
-                # sometimes sending "null" for attachments leads to an error
-                # when it works it has the same effect as sending an empty JSON array
-                attachments = []
-              else
-                attachments = options[:attachments]
-              end
+              attachments = options[:attachments]
+              # sometimes sending "null" for attachments leads to an error
+              # when it works it has the same effect as sending an empty JSON array
+              attachments = [] if attachments.nil?
               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
               options = options.merge(attachments: attachments)
             end

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -213,7 +213,13 @@ module Slack
             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
-              attachments = options[:attachments]
+              if options[:attachments].nil?
+                # sometimes sending "null" for attachments leads to an error
+                # when it works it has the same effect as sending an empty JSON array
+                attachments = []
+              else
+                attachments = options[:attachments]
+              end
               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
               options = options.merge(attachments: attachments)
             end

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -98,9 +98,15 @@ module Slack
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
-              attachments = options[:attachments]
-              attachments = JSON.dump(attachments) unless attachments.is_a?(String)
-              options = options.merge(attachments: attachments)
+              if options[:attachments].nil?
+                # sometimes sending "null" for "attachments" leads to an error
+                # when it works it has the same effect as sending no attachments at all
+                options.delete(:attachments)
+              else
+                attachments = options[:attachments]
+                attachments = JSON.dump(attachments) unless attachments.is_a?(String)
+                options = options.merge(attachments: attachments)
+              end
             end
             post('chat.postEphemeral', options)
           end
@@ -143,9 +149,15 @@ module Slack
             throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
-              attachments = options[:attachments]
-              attachments = JSON.dump(attachments) unless attachments.is_a?(String)
-              options = options.merge(attachments: attachments)
+              if options[:attachments].nil?
+                # sometimes sending "null" for "attachments" leads to an error
+                # when it works it has the same effect as sending no attachments at all
+                options.delete(:attachments)
+              else
+                attachments = options[:attachments]
+                attachments = JSON.dump(attachments) unless attachments.is_a?(String)
+                options = options.merge(attachments: attachments)
+              end
             end
             post('chat.postMessage', options)
           end

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
 
   context 'chat_update' do
     let(:ts) { '1405894322.002768' }
-    it 'automatically converts attachments into JSON' do
+    it 'replaces nil attachments with an empty array' do
       expect(client).to receive(:post).with(
         'chat.update',
         attachments: '[]',
@@ -98,7 +98,17 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
         text: 'text',
         ts: ts
       )
-      client.chat_update(attachments: [], channel: 'channel', text: 'text', ts: ts)
+      client.chat_update(attachments: nil, channel: 'channel', text: 'text', ts: ts)
+    end
+    it 'automatically converts attachments into JSON' do
+      expect(client).to receive(:post).with(
+        'chat.update',
+        attachments: '[{"text":"foo"},{"text":"bar"}]',
+        channel: 'channel',
+        text: 'text',
+        ts: ts
+      )
+      client.chat_update(attachments: [{text: 'foo'},{text: 'bar'}], channel: 'channel', text: 'text', ts: ts)
     end
     context 'ts arguments' do
       it 'requires ts' do

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
         text: 'text',
         ts: ts
       )
-      client.chat_update(attachments: [{text: 'foo'},{text: 'bar'}], channel: 'channel', text: 'text', ts: ts)
+      client.chat_update(attachments: [{ text: 'foo' }, { text: 'bar' }], channel: 'channel', text: 'text', ts: ts)
     end
     context 'ts arguments' do
       it 'requires ts' do

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
       allow(described_class).to receive(:users_id).and_return(user)
     end
 
+    it 'removes attachments if it is nil' do
+      expect(client).to receive(:post).with(
+        'chat.postEphemeral',
+        channel: 'channel',
+        text: 'text',
+        user: '123'
+      )
+      client.chat_postEphemeral(channel: 'channel', text: 'text', user: '123', attachments: nil)
+    end
     it 'automatically converts attachments into JSON' do
       expect(client).to receive(:post).with(
         'chat.postEphemeral',
@@ -43,6 +52,14 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
   end
 
   context 'chat_postMessage' do
+    it 'removes attachments if it is nil' do
+      expect(client).to receive(:post).with(
+        'chat.postMessage',
+        channel: 'channel',
+        text: 'text'
+      )
+      client.chat_postMessage(channel: 'channel', text: 'text', attachments: nil)
+    end
     it 'automatically converts attachments into JSON' do
       expect(client).to receive(:post).with(
         'chat.postMessage',


### PR DESCRIPTION
In our app we started receiving some `invalid_attachments_format` errors for certain workspaces, and I tracked it down to a few spots where we pass `attachments: nil` into `chat_postMessage`. I took a look in here to see what happens when you pass `attachments: nil` and the answer is that the JSON string for `attachments` is `null`. I was able to get around this error by simply omitting `attachments` instead.

We've actually have been doing this for a long time and it's never been a problem before, so I contacted Slack about it and they've identified it as a bug related to a beta feature for certain workspaces.

But there's really no good reason to ever send `null` for attachments, so I thought it might make sense to avoid that.

The change to `chat_update` is perhaps less self-explanatory than `chat_postMessage` and `chat_ephemeral`. Here's how `chat_update` behaves with `attachments`:

- omit `attachments`:
  - If there are existing attachments leave them alone
  - If there are no existing attachments don't add any
- pass `attachments` as `"[]"` or `null`:
  - Remove any existing attachments, if they exist
  - If there are no existing attachments don't add any

Anyway, I'm curious if you think this is an appropriate safeguard to add to this library, or not.