### PR TITLE
Implementing #restart for the Celluloid Socket class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#226](https://github.com/slack-ruby/slack-ruby-client/pull/226), [#232](https://github.com/slack-ruby/slack-ruby-client/pull/232), [#236](https://github.com/slack-ruby/slack-ruby-client/pull/236), [#234](https://github.com/slack-ruby/slack-ruby-client/pull/234): Added periodic ping that reconnects on failure - [@RodneyU215](https://github.com/RodneyU215), [@dblock](https://github.com/dblock), [@ioquatix](https://github.com/ioquatix).
 * [#242](https://github.com/slack-ruby/slack-ruby-client/pull/242): Added `thread_ts` option to `chat_postEphemeral` - [@dblock](https://github.com/dblock).
 * [#242](https://github.com/slack-ruby/slack-ruby-client/pull/242): Added `apps_uninstall` to Web API - [@dblock](https://github.com/dblock).
+* [#244](https://github.com/slack-ruby/slack-ruby-client/pull/244): Implementing #restart for the celluloid socket class - [@RodneyU215](https://github.com/RodneyU215).
 * Your contribution here.
 
 ### 0.13.1 (2018/9/30)

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -106,7 +106,7 @@ module Slack
       def run_ping!
         time_since_last_message = @socket.time_since_last_message
         return if time_since_last_message < websocket_ping
-        raise Slack::RealTime::Client::ClientNotStartedError if time_since_last_message > (websocket_ping * 2)
+        raise Slack::RealTime::Client::ClientNotStartedError if !@socket.connected? || time_since_last_message > (websocket_ping * 2)
 
         ping
       rescue Slack::RealTime::Client::ClientNotStartedError

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -37,12 +37,11 @@ module Slack
           rescue EOFError, Errno::ECONNRESET, Errno::EPIPE => e
             logger.debug("#{self.class}##{__method__}") { e }
             driver.emit(:close, WebSocket::Driver::CloseEvent.new(1001, 'server closed connection')) unless @closing
-          ensure
-            begin
-              current_actor.terminate if current_actor.alive?
-            rescue StandardError
-              nil
-            end
+          end
+
+          def disconnect!
+            super
+            current_actor.terminate if current_actor.alive?
           end
 
           def close
@@ -84,6 +83,13 @@ module Slack
           rescue StandardError => e
             logger.debug("#{self.class}##{__method__}") { e }
             raise e
+          end
+
+          def restart_async(client, new_url)
+            @url = new_url
+            @client = client
+
+            @client.run_loop
           end
 
           def connected?

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -41,7 +41,7 @@ module Slack
 
           def disconnect!
             super
-            @ping_timer.cancel
+            @ping_timer.cancel if @ping_timer
           end
 
           def close

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -41,7 +41,7 @@ module Slack
 
           def disconnect!
             super
-            current_actor.terminate if current_actor.alive?
+            @ping_timer.cancel
           end
 
           def close
@@ -74,7 +74,7 @@ module Slack
 
           def run_client_loop
             if @client.run_ping?
-              current_actor.every @client.websocket_ping do
+              @ping_timer = every @client.websocket_ping do
                 @client.run_ping!
               end
             end

--- a/lib/slack/real_time/concurrency/eventmachine.rb
+++ b/lib/slack/real_time/concurrency/eventmachine.rb
@@ -52,7 +52,7 @@ module Slack
 
           def disconnect!
             super
-            EventMachine.stop if @thread
+            EventMachine.stop_event_loop if EventMachine.reactor_running?
             @thread = nil
           end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -133,6 +133,7 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
       @reply_to = nil
       client.on :pong do |data|
         @reply_to = data.reply_to
+        queue.push nil
         client.stop!
       end
       start_server
@@ -146,14 +147,13 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
         if @reply_to == 1
           client.instance_variable_get(:@socket).close
         else
-          expect(@reply_to).to be 3
-          # Note: next_id auto increments the id during the 2nd ping attempt.
-          # Since we've forced this request to fail by closing the @socket above,
-          # The next successful pong response should be the 3rd attempt.
+          expect(@reply_to).to be 2
+          queue.push nil
           client.stop!
         end
       end
       start_server
+      queue.pop_with_timeout(10)
       queue.pop_with_timeout(10)
     end
   end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
 
   let(:logger) do
     logger = Logger.new(STDOUT)
-    logger.level = Logger::DEBUG
+    logger.level = Logger::INFO
     logger
   end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
 
   let(:logger) do
     logger = Logger.new(STDOUT)
-    logger.level = Logger::INFO
+    logger.level = Logger::DEBUG
     logger
   end
 
@@ -138,16 +138,6 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
       start_server
       queue.pop_with_timeout(5)
       expect(@reply_to).to be 1
-    end
-    it 'no longer sends pings when #disconnect! is called' do
-      @reply_to = nil
-      client.on :pong do |data|
-        @reply_to = data.reply_to
-        client.stop! if data.reply_to == 2
-      end
-      start_server
-      queue.pop_with_timeout(10)
-      expect(@reply_to).to be 2
     end
   end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -136,8 +136,18 @@ RSpec.describe 'integration test', skip: (!ENV['SLACK_API_TOKEN'] || !ENV['CONCU
         client.stop!
       end
       start_server
-      wait_for_server
+      queue.pop_with_timeout(5)
       expect(@reply_to).to be 1
+    end
+    it 'no longer sends pings when #disconnect! is called' do
+      @reply_to = nil
+      client.on :pong do |data|
+        @reply_to = data.reply_to
+        client.stop! if data.reply_to == 2
+      end
+      start_server
+      queue.pop_with_timeout(10)
+      expect(@reply_to).to be 2
     end
   end
 


### PR DESCRIPTION
I've also relocated the call to terminate the actor to the disconnect method. This finishes up the implementation so that Celluloid correctly handles restarts. See https://github.com/slack-ruby/slack-ruby-client/pull/236 for details.

Please hold off on merging though as I'm still working through testing these changes.