### PR TITLE
Add support for Block Kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#242](https://github.com/slack-ruby/slack-ruby-client/pull/242): Added `apps_uninstall` to Web API - [@dblock](https://github.com/dblock).
 * [#244](https://github.com/slack-ruby/slack-ruby-client/pull/244): Implementing #restart for the celluloid socket class - [@RodneyU215](https://github.com/RodneyU215).
 * [#246](https://github.com/slack-ruby/slack-ruby-client/pull/246): Added TOC to README and danger-toc - [@dblock](https://github.com/dblock).
+* [#253](https://github.com/slack-ruby/slack-ruby-client/pull/253): Support for Block Kit - [@JrmKrb](https://github.com/JrmKrb).
 * Your contribution here.
 
 ### 0.13.1 (2018/9/30)

--- a/bin/commands/chat.rb
+++ b/bin/commands/chat.rb
@@ -52,6 +52,7 @@ command 'chat' do |g|
     c.flag 'user', desc: 'id of the user who will receive the ephemeral message. The user should be in the channel specified by the channel argument.'
     c.flag 'as_user', desc: 'Pass true to post the message as the authed user. Defaults to true if the chat:write:bot scope is not included. Otherwise, defaults to false.'
     c.flag 'attachments', desc: 'A JSON-based array of structured attachments, presented as a URL-encoded string.'
+    c.flag 'blocks', desc: 'A JSON-based array of structured blocks, presented as a URL-encoded string.'
     c.flag 'link_names', desc: 'Find and link channel names and usernames.'
     c.flag 'parse', desc: 'Change how messages are treated. Defaults to none. See below.'
     c.flag 'thread_ts', desc: "Provide another message's ts value to make this message a reply. Avoid using a reply's ts value; use its parent instead."
@@ -67,6 +68,7 @@ command 'chat' do |g|
     c.flag 'text', desc: "Text of the message to send. See below for an explanation of formatting. This field is usually required, unless you're providing only attachments instead. Provide no more than 40,000 characters or risk truncation."
     c.flag 'as_user', desc: 'Pass true to post the message as the authed user, instead of as a bot. Defaults to false. See authorship below.'
     c.flag 'attachments', desc: 'A JSON-based array of structured attachments, presented as a URL-encoded string.'
+    c.flag 'blocks', desc: 'A JSON-based array of structured blocks, presented as a URL-encoded string.'
     c.flag 'icon_emoji', desc: 'Emoji to use as the icon for this message. Overrides icon_url. Must be used in conjunction with as_user set to false, otherwise ignored. See authorship below.'
     c.flag 'icon_url', desc: 'URL to an image to use as the icon for this message. Must be used in conjunction with as_user set to false, otherwise ignored. See authorship below.'
     c.flag 'link_names', desc: 'Find and link channel names and usernames.'
@@ -104,6 +106,7 @@ command 'chat' do |g|
     c.flag 'ts', desc: 'Timestamp of the message to be updated.'
     c.flag 'as_user', desc: 'Pass true to update the message as the authed user. Bot users in this context are considered authed users.'
     c.flag 'attachments', desc: 'A JSON-based array of structured attachments, presented as a URL-encoded string. This field is required when not presenting text.'
+    c.flag 'blocks', desc: 'A JSON-based array of structured blocks, presented as a URL-encoded string.'
     c.flag 'link_names', desc: 'Find and link channel names and usernames. Defaults to none. See below.'
     c.flag 'parse', desc: 'Change how messages are treated. Defaults to client, unlike chat.postMessage. See below.'
     c.action do |_global_options, options, _args|

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -97,7 +97,7 @@ module Slack
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postEphemeral.json
           def chat_postEphemeral(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
+            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
             throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             # attachments must be passed as an encoded JSON string
@@ -105,6 +105,12 @@ module Slack
               attachments = options[:attachments]
               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
               options = options.merge(attachments: attachments)
+            end
+            # blocks must be passed as an encoded JSON string
+            if options.key?(:blocks)
+              blocks = options[:blocks]
+              blocks = JSON.dump(blocks) unless blocks.is_a?(String)
+              options = options.merge(blocks: blocks)
             end
             post('chat.postEphemeral', options)
           end
@@ -146,12 +152,18 @@ module Slack
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postMessage.json
           def chat_postMessage(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
+            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
               attachments = options[:attachments]
               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
               options = options.merge(attachments: attachments)
+            end
+            # blocks must be passed as an encoded JSON string
+            if options.key?(:blocks)
+              blocks = options[:blocks]
+              blocks = JSON.dump(blocks) unless blocks.is_a?(String)
+              options = options.merge(blocks: blocks)
             end
             post('chat.postMessage', options)
           end
@@ -204,7 +216,7 @@ module Slack
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.update.json
           def chat_update(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
+            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
             throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
             # attachments must be passed as an encoded JSON string
@@ -212,6 +224,12 @@ module Slack
               attachments = options[:attachments]
               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
               options = options.merge(attachments: attachments)
+            end
+            # blocks must be passed as an encoded JSON string
+            if options.key?(:blocks)
+              blocks = options[:blocks]
+              blocks = JSON.dump(blocks) unless blocks.is_a?(String)
+              options = options.merge(blocks: blocks)
             end
             post('chat.update', options)
           end

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -85,6 +85,8 @@ module Slack
           #   Pass true to post the message as the authed user. Defaults to true if the chat:write:bot scope is not included. Otherwise, defaults to false.
           # @option options [Object] :attachments
           #   A JSON-based array of structured attachments, presented as a URL-encoded string.
+          # @option options [Object] :blocks
+          #   A JSON-based array of structured blocks, presented as a URL-encoded string.
           # @option options [Object] :link_names
           #   Find and link channel names and usernames.
           # @option options [Object] :parse
@@ -118,6 +120,8 @@ module Slack
           #   Pass true to post the message as the authed user, instead of as a bot. Defaults to false. See authorship below.
           # @option options [Object] :attachments
           #   A JSON-based array of structured attachments, presented as a URL-encoded string.
+          # @option options [Object] :blocks
+          #   A JSON-based array of structured blocks, presented as a URL-encoded string.
           # @option options [Object] :icon_emoji
           #   Emoji to use as the icon for this message. Overrides icon_url. Must be used in conjunction with as_user set to false, otherwise ignored. See authorship below.
           # @option options [Object] :icon_url
@@ -190,6 +194,8 @@ module Slack
           #   Pass true to update the message as the authed user. Bot users in this context are considered authed users.
           # @option options [Object] :attachments
           #   A JSON-based array of structured attachments, presented as a URL-encoded string. This field is required when not presenting text.
+          # @option options [Object] :blocks
+          #   A JSON-based array of structured blocks, presented as a URL-encoded string.
           # @option options [Object] :link_names
           #   Find and link channel names and usernames. Defaults to none. See below.
           # @option options [Object] :parse

--- a/lib/slack/web/api/patches/chat.6.block-kit-support.patch
+++ b/lib/slack/web/api/patches/chat.6.block-kit-support.patch
@@ -1,0 +1,69 @@
+diff --git a/lib/slack/web/api/endpoints/chat.rb b/lib/slack/web/api/endpoints/chat.rb
+index 54a7db1..c535bb5 100644
+--- a/lib/slack/web/api/endpoints/chat.rb
++++ b/lib/slack/web/api/endpoints/chat.rb
+@@ -97,7 +97,7 @@ module Slack
+           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postEphemeral.json
+           def chat_postEphemeral(options = {})
+             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+-            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
++            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+             throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
+             # attachments must be passed as an encoded JSON string
+@@ -106,6 +106,12 @@ module Slack
+               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
+               options = options.merge(attachments: attachments)
+             end
++            # blocks must be passed as an encoded JSON string
++            if options.key?(:blocks)
++              blocks = options[:blocks]
++              blocks = JSON.dump(blocks) unless blocks.is_a?(String)
++              options = options.merge(blocks: blocks)
++            end
+             post('chat.postEphemeral', options)
+           end
+ 
+@@ -146,13 +152,19 @@ module Slack
+           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postMessage.json
+           def chat_postMessage(options = {})
+             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+-            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
++            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+             # attachments must be passed as an encoded JSON string
+             if options.key?(:attachments)
+               attachments = options[:attachments]
+               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
+               options = options.merge(attachments: attachments)
+             end
++            # blocks must be passed as an encoded JSON string
++            if options.key?(:blocks)
++              blocks = options[:blocks]
++              blocks = JSON.dump(blocks) unless blocks.is_a?(String)
++              options = options.merge(blocks: blocks)
++            end
+             post('chat.postMessage', options)
+           end
+ 
+@@ -204,7 +216,7 @@ module Slack
+           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.update.json
+           def chat_update(options = {})
+             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+-            throw ArgumentError.new('Required arguments :text or :attachments missing') if options[:text].nil? && options[:attachments].nil?
++            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+             throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
+             options = options.merge(channel: channels_id(options)['channel']['id']) if options[:channel]
+             # attachments must be passed as an encoded JSON string
+@@ -213,6 +225,12 @@ module Slack
+               attachments = JSON.dump(attachments) unless attachments.is_a?(String)
+               options = options.merge(attachments: attachments)
+             end
++            # blocks must be passed as an encoded JSON string
++            if options.key?(:blocks)
++              blocks = options[:blocks]
++              blocks = JSON.dump(blocks) unless blocks.is_a?(String)
++              options = options.merge(blocks: blocks)
++            end
+             post('chat.update', options)
+           end
+         end

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -8,19 +8,20 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
       allow(described_class).to receive(:users_id).and_return(user)
     end
 
-    it 'automatically converts attachments into JSON' do
+    it 'automatically converts attachments and blocks into JSON' do
       expect(client).to receive(:post).with(
         'chat.postEphemeral',
         channel: 'channel',
         text: 'text',
         user: '123',
-        attachments: '[]'
+        attachments: '[]',
+        blocks: '[]'
       )
-      client.chat_postEphemeral(channel: 'channel', text: 'text', user: '123', attachments: [])
+      client.chat_postEphemeral(channel: 'channel', text: 'text', user: '123', attachments: [], blocks: [])
     end
     context 'text and user arguments' do
       it 'requires text or attachments' do
-        expect { client.chat_postEphemeral(channel: 'channel') }.to raise_error ArgumentError, /Required arguments :text or :attachments missing/
+        expect { client.chat_postEphemeral(channel: 'channel') }.to raise_error ArgumentError, /Required arguments :text, :attachments or :blocks missing/
       end
       it 'requires user' do
         expect { client.chat_postEphemeral(channel: 'channel', text: 'text') }.to raise_error ArgumentError, /Required arguments :user missing/
@@ -40,21 +41,32 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
         expect { client.chat_postEphemeral(channel: 'channel', attachments: [], user: '123') }.to_not raise_error
       end
     end
+    context 'blocks argument' do
+      it 'optional blocks' do
+        expect(client).to receive(:post).with('chat.postEphemeral', hash_including(blocks: '[]'))
+        expect { client.chat_postEphemeral(channel: 'channel', text: 'text', user: '123', blocks: []) }.to_not raise_error
+      end
+      it 'blocks without text' do
+        expect(client).to receive(:post).with('chat.postEphemeral', hash_including(blocks: '[]'))
+        expect { client.chat_postEphemeral(channel: 'channel', blocks: [], user: '123') }.to_not raise_error
+      end
+    end
   end
 
   context 'chat_postMessage' do
-    it 'automatically converts attachments into JSON' do
+    it 'automatically converts attachments and blocks into JSON' do
       expect(client).to receive(:post).with(
         'chat.postMessage',
         channel: 'channel',
         text: 'text',
-        attachments: '[]'
+        attachments: '[]',
+        blocks: '[]'
       )
-      client.chat_postMessage(channel: 'channel', text: 'text', attachments: [])
+      client.chat_postMessage(channel: 'channel', text: 'text', attachments: [], blocks: [])
     end
-    context 'text and attachment arguments' do
-      it 'requires text or attachments' do
-        expect { client.chat_postMessage(channel: 'channel') }.to raise_error ArgumentError, /Required arguments :text or :attachments missing/
+    context 'text, attachment and blocks arguments' do
+      it 'requires text, attachments or blocks' do
+        expect { client.chat_postMessage(channel: 'channel') }.to raise_error ArgumentError, /Required arguments :text, :attachments or :blocks missing/
       end
       it 'only text' do
         expect(client).to receive(:post).with('chat.postMessage', hash_including(text: 'text'))
@@ -64,33 +76,38 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
         expect(client).to receive(:post).with('chat.postMessage', hash_including(attachments: '[]'))
         expect { client.chat_postMessage(channel: 'channel', attachments: []) }.to_not raise_error
       end
-      it 'both text and attachments' do
-        expect(client).to receive(:post).with('chat.postMessage', hash_including(text: 'text', attachments: '[]'))
-        expect { client.chat_postMessage(channel: 'channel', text: 'text', attachments: []) }.to_not raise_error
+      it 'only blocks' do
+        expect(client).to receive(:post).with('chat.postMessage', hash_including(blocks: '[]'))
+        expect { client.chat_postMessage(channel: 'channel', blocks: []) }.to_not raise_error
+      end
+      it 'all text, attachments and blocks' do
+        expect(client).to receive(:post).with('chat.postMessage', hash_including(text: 'text', attachments: '[]', blocks: '[]'))
+        expect { client.chat_postMessage(channel: 'channel', text: 'text', attachments: [], blocks: []) }.to_not raise_error
       end
     end
   end
 
   context 'chat_update' do
     let(:ts) { '1405894322.002768' }
-    it 'automatically converts attachments into JSON' do
+    it 'automatically converts attachments and blocks into JSON' do
       expect(client).to receive(:post).with(
         'chat.update',
-        attachments: '[]',
         channel: 'channel',
         text: 'text',
-        ts: ts
+        ts: ts,
+        attachments: '[]',
+        blocks: '[]'
       )
-      client.chat_update(attachments: [], channel: 'channel', text: 'text', ts: ts)
+      client.chat_update(channel: 'channel', text: 'text', ts: ts, attachments: [], blocks: [])
     end
     context 'ts arguments' do
       it 'requires ts' do
         expect { client.chat_update(channel: 'channel', text: 'text') }.to raise_error ArgumentError, /Required arguments :ts missing>/
       end
     end
-    context 'text and attachment arguments' do
-      it 'requires text or attachments' do
-        expect { client.chat_update(channel: 'channel', ts: ts) }.to raise_error ArgumentError, /Required arguments :text or :attachments missing/
+    context 'text, attachment and blocks arguments' do
+      it 'requires text, attachments or blocks' do
+        expect { client.chat_update(channel: 'channel', ts: ts) }.to raise_error ArgumentError, /Required arguments :text, :attachments or :blocks missing/
       end
       it 'only text' do
         expect(client).to receive(:post).with('chat.update', hash_including(text: 'text'))
@@ -98,11 +115,15 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
       end
       it 'only attachments' do
         expect(client).to receive(:post).with('chat.update', hash_including(attachments: '[]'))
-        expect { client.chat_update(attachments: [], channel: 'channel', ts: ts) }.to_not raise_error
+        expect { client.chat_update(channel: 'channel', ts: ts, attachments: []) }.to_not raise_error
       end
-      it 'both text and attachments' do
-        expect(client).to receive(:post).with('chat.update', hash_including(text: 'text', attachments: '[]'))
-        expect { client.chat_update(attachments: [], channel: 'channel', text: 'text', ts: ts) }.to_not raise_error
+      it 'only blocks' do
+        expect(client).to receive(:post).with('chat.update', hash_including(blocks: '[]'))
+        expect { client.chat_update(channel: 'channel', ts: ts, blocks: []) }.to_not raise_error
+      end
+      it 'all text, attachments and blocks' do
+        expect(client).to receive(:post).with('chat.update', hash_including(text: 'text', attachments: '[]', blocks: '[]'))
+        expect { client.chat_update(channel: 'channel', text: 'text', ts: ts, attachments: [], blocks: []) }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
- Updates Slack API
- Patches Blocks to be JSON-string encoded
- Specs

I think it's ready to merge and it would be nice to have it released soon.

It closes #251 and takes the place of #252 that was not patching properly the Web API to mimic attachments behavior.