### PR TITLE
Fix: celluloid infinite reconnect loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.14.1 (Next)
 
+* [#254](https://github.com/slack-ruby/slack-ruby-client/issues/254): Fix: celluloid infinite reconnect loop - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 0.14.0 (2019/2/25)

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -69,8 +69,8 @@ module Slack
 
           def start_async(client)
             @client = client
-            Actor.new(future.run_client_loop)
             Actor.new(future.run_ping_loop)
+            Actor.new(future.run_client_loop)
           end
 
           def run_client_loop


### PR DESCRIPTION
If I understand this correctly we're not returning the correct promise.

The ping worker returns a `#<Timers::Timer: fires in 29.99997400000575 seconds, recurs every 30>` which cannot be joined.

The loop returns a future, `#<Celluloid::Future>` which can be joined.

Fixes #254 

cc: @RodneyU215 in case I am missing something