### PR TITLE
Add support for specifying signing secrets on a per-request basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.14.2 (Next)
 
+* [#256](https://github.com/slack-ruby/slack-ruby-client/pull/256): Added support for specifying signing secrets on a per-request basis via optional parameters to the `Slack::Events::Request` constructor - [@gabrielmdeal](https://github.com/gabrielmdeal).
 * Your contribution here.
 
 ### 0.14.1 (2019/2/26)

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ To specify secrets on a per-request basis:
 ```ruby
 Slack::Events::Request.new(http_request,
                            signing_secret: signing_secret,
-                           signature_expires_in: signature_expires_in))
+						   signature_expires_in: signature_expires_in)
 ```
 
 The `verify!` call may raise `Slack::Events::MissingSigningSecret`, `Slack::Events::InvalidSignature` or `Slack::Events::TimestampExpired` errors.

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ To specify secrets on a per-request basis:
 ```ruby
 Slack::Events::Request.new(http_request,
                            signing_secret: signing_secret,
-						   signature_expires_in: signature_expires_in)
+                           signature_expires_in: signature_expires_in)
 ```
 
 The `verify!` call may raise `Slack::Events::MissingSigningSecret`, `Slack::Events::InvalidSignature` or `Slack::Events::TimestampExpired` errors.

--- a/README.md
+++ b/README.md
@@ -506,6 +506,13 @@ slack_request = Slack::Events::Request.new(http_request)
 slack_request.verify!
 ```
 
+To specify secrets on a per-request basis:
+```ruby
+Slack::Events::Request.new(http_request,
+                           signing_secret: signing_secret,
+                           signature_expires_in: signature_expires_in))
+```
+
 The `verify!` call may raise `Slack::Events::MissingSigningSecret`, `Slack::Events::InvalidSignature` or `Slack::Events::TimestampExpired` errors.
 
 ### Message Parsing

--- a/lib/slack/events/request.rb
+++ b/lib/slack/events/request.rb
@@ -5,10 +5,16 @@ module Slack
       class TimestampExpired < StandardError; end
       class InvalidSignature < StandardError; end
 
-      attr_reader :http_request
+      attr_reader :http_request,
+                  :signing_secret,
+                  :signature_expires_in
 
-      def initialize(http_request)
+      def initialize(http_request,
+                     signing_secret: Slack::Events.config.signing_secret,
+                     signature_expires_in: Slack::Events.config.signature_expires_in)
         @http_request = http_request
+        @signing_secret = signing_secret
+        @signature_expires_in = signature_expires_in
       end
 
       # Request timestamp.
@@ -34,16 +40,16 @@ module Slack
 
       # Returns true if the signature coming from Slack has expired.
       def expired?
-        timestamp.nil? || (Time.now.to_i - timestamp.to_i).abs > Slack::Events.config.signature_expires_in
+        timestamp.nil? || (Time.now.to_i - timestamp.to_i).abs > signature_expires_in
       end
 
       # Returns true if the signature coming from Slack is valid.
       def valid?
-        raise MissingSigningSecret unless Slack::Events.config.signing_secret
+        raise MissingSigningSecret unless signing_secret
 
         digest = OpenSSL::Digest::SHA256.new
         signature_basestring = [version, timestamp, body].join(':')
-        hex_hash = OpenSSL::HMAC.hexdigest(digest, Slack::Events.config.signing_secret, signature_basestring)
+        hex_hash = OpenSSL::HMAC.hexdigest(digest, signing_secret, signature_basestring)
         computed_signature = [version, hex_hash].join('=')
         computed_signature == signature
       end

--- a/lib/slack/events/request.rb
+++ b/lib/slack/events/request.rb
@@ -9,12 +9,10 @@ module Slack
                   :signing_secret,
                   :signature_expires_in
 
-      def initialize(http_request,
-                     signing_secret: Slack::Events.config.signing_secret,
-                     signature_expires_in: Slack::Events.config.signature_expires_in)
+      def initialize(http_request, options = {})
         @http_request = http_request
-        @signing_secret = signing_secret
-        @signature_expires_in = signature_expires_in
+        @signing_secret = options[:signing_secret] || Slack::Events.config.signing_secret
+        @signature_expires_in = options[:signature_expires_in] || Slack::Events.config.signature_expires_in
       end
 
       # Request timestamp.


### PR DESCRIPTION
For services that handle requests from multiple Slack applications.

Example:
```ruby
Slack::Events::Request.new(http_request,
                           signing_secret: signing_secret,
                           signature_expires_in: signature_expires_in))
```
