### PR TITLE
Fix: celluloid integration specs and eventmachine double-close.

### DIFF
--- a/lib/slack/real_time/concurrency/async.rb
+++ b/lib/slack/real_time/concurrency/async.rb
@@ -88,7 +88,13 @@ module Slack
 
           # Close the socket.
           def close
-            super
+            if driver = @driver
+              # When you call `driver.emit(:close)`, it will typically end up calling `client.close`
+              # which will call `@socket.close` and end up back here. In order to break this infinite recursion,
+              # we check and set `@driver = nil` before invoking `client.close`.
+              @driver = nil
+              driver.emit(:close)
+            end
           ensure
             if @socket
               @socket.close

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -46,7 +46,10 @@ module Slack
 
           def close
             @closing = true
-            super
+            if driver = @driver
+              @driver = nil
+              driver.close
+            end
           end
 
           def read

--- a/lib/slack/real_time/concurrency/eventmachine.rb
+++ b/lib/slack/real_time/concurrency/eventmachine.rb
@@ -61,6 +61,13 @@ module Slack
             driver.send(message)
           end
 
+          def close
+            if driver = @driver
+              @driver = nil
+              driver.close
+            end
+          end
+
           protected
 
           # @return [Thread]

--- a/lib/slack/real_time/socket.rb
+++ b/lib/slack/real_time/socket.rb
@@ -76,11 +76,7 @@ module Slack
       end
 
       def close
-        # When you call `driver.emit(:close)`, it will typically end up calling `client.close` which will call `@socket.close` and end up back here. In order to break this infinite recursion, we check and set `@driver = nil` before invoking `client.close`.
-        if driver = @driver
-          @driver = nil
-          driver.emit(:close)
-        end
+        raise NotImplementedError, "Expected #{self.class} to implement #{__method__}."
       end
 
       protected


### PR DESCRIPTION
Attempted followup to #262. 

Celluloid integration spec is failing. The closing behavior seems to be different across concurrency libraries. Eventmachine emits `:close` all by itself, while celluloid ... who knows, but this works more often.

Still debugging. 