### PR TITLE
Pin `async-websocket` to stable version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ gem 'slack-ruby-client'
 If you're going to be using the RealTime client, add either `async-websocket`, `eventmachine` and `faye-websocket` or `celluloid-io`. See below for more information about concurrency. We recommend you use `async-websocket`.
 
 ```
-gem 'async-websocket'
+gem 'async-websocket', '~> 0.8.0'
 ```
 
 Run `bundle install`.


### PR DESCRIPTION
`v0.9.0` will contain breaking changes, but the updated interface should also be more stable.