### PR TITLE
Fix reconnects when ping timers under/overshoot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.14.4 (Next)
 
+* [#289](https://github.com/slack-ruby/slack-ruby-client/pull/289): Fix reconnects when ping timers under/overshoot - [@georgyangelov](https://github.com/georgyangelov).
 * Your contribution here.
 
 ### 0.14.3 (2019/7/23)

--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ This setting determines how long the socket can be idle before sending a ping me
 
 It's important to note that if a ping message was sent and no response was received within the amount of time specified in `websocket_ping`; the client will attempt to reestablish it's connection to the message server.
 
+Note that the ping may take between `websocket_ping` and `websocket_ping * 3/2` seconds to actually trigger when there is no activity on the socket. This is because the timer that checks whether to ping is triggered at every `websocket_ping / 2` interval (see [#289](https://github.com/slack-ruby/slack-ruby-client/pull/289) for further explanation).
+
 To disable this feature; set `websocket_ping` to 0.
 
 ### Connection Methods

--- a/lib/slack/real_time/concurrency/async.rb
+++ b/lib/slack/real_time/concurrency/async.rb
@@ -34,7 +34,7 @@ module Slack
 
                   # The timer task will naturally exit after the driver is set to nil.
                   while @restart
-                    subtask.sleep client.websocket_ping
+                    subtask.sleep client.websocket_ping_timer
                     client.run_ping! if @restart
                   end
                 end

--- a/lib/slack/real_time/concurrency/celluloid.rb
+++ b/lib/slack/real_time/concurrency/celluloid.rb
@@ -82,7 +82,7 @@ module Slack
           def run_ping_loop
             return unless @client.run_ping?
 
-            @ping_timer = every @client.websocket_ping do
+            @ping_timer = every @client.websocket_ping_timer do
               @client.run_ping!
             end
           end

--- a/lib/slack/real_time/concurrency/eventmachine.rb
+++ b/lib/slack/real_time/concurrency/eventmachine.rb
@@ -30,7 +30,7 @@ module Slack
             @thread = ensure_reactor_running
 
             if client.run_ping?
-              EventMachine.add_periodic_timer(client.websocket_ping) do
+              EventMachine.add_periodic_timer client.websocket_ping_timer do
                 client.run_ping!
               end
             end

--- a/lib/slack/real_time/config.rb
+++ b/lib/slack/real_time/config.rb
@@ -33,6 +33,10 @@ module Slack
         (val = @concurrency).respond_to?(:call) ? val.call : val
       end
 
+      def websocket_ping_timer
+        websocket_ping / 2
+      end
+
       private
 
       def detect_concurrency


### PR DESCRIPTION
The ping timer is set exactly on the ping interval. Sometimes the timer runs a bit before the ping time so the ping misses. If the next timer overshoots, the ping is not sent and the connection is restarted
(because the last message time is > ping_time*2). 

Scheduling the timer more frequently than the actual ping time fixes these issues as the timer is guaranteed to ping at least once during the ping_time*2 interval.

Here is an example of what happens:

```
D, [2019-07-26T16:49:15.839429 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#keep_alive?: Websocket ping time is 30
D, [2019-07-26T16:49:15.839698 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#keep_alive?: Time since last message: 37.04522261582315
D, [2019-07-26T16:49:15.839805 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#send_json: {:type=>"ping", :id=>2}
D, [2019-07-26T16:49:15.839994 #7] DEBUG -- Slack::RealTime::Concurrency::Async::Socket#send_data: {"type":"ping","id":2}
D, [2019-07-26T16:49:15.873663 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#run_loop: WebSocket::Driver::MessageEvent, {"type":"pong","reply_to":2}
D, [2019-07-26T16:49:15.874079 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#dispatch: reply_to=2, type=pong


D, [2019-07-26T16:49:45.865965 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#keep_alive?: Websocket ping time is 30
D, [2019-07-26T16:49:45.867134 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#keep_alive?: Time since last message: 29.992787840776145


D, [2019-07-26T16:50:15.895730 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#keep_alive?: Websocket ping time is 30
D, [2019-07-26T16:50:15.896235 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#keep_alive?: Time since last message: 60.022549238055944
W, [2019-07-26T16:50:15.896895 #7]  WARN -- id=TEAMID, name=TEAMNAME, domain=team: is offline
D, [2019-07-26T16:50:15.897195 #7] DEBUG -- : id=TEAMID, name=TEAMNAME, domain=team#restart_async
D, [2019-07-26T16:50:15.897333 #7] DEBUG -- id=TEAMID, name=TEAMNAME, domain=team#run_loop: NilClass
I, [2019-07-26T16:50:15.900166 #7]  INFO -- request: POST https://slack.com/api/rtm.start
```

Please note that I haven't tested the Celluloid or EventMachine implementations, just the Async one.