### PR TITLE
Raise Slack-scoped exception if response not JSON

### DIFF
--- a/lib/slack/web/faraday/response/raise_error.rb
+++ b/lib/slack/web/faraday/response/raise_error.rb
@@ -6,6 +6,7 @@ module Slack
         class RaiseError < ::Faraday::Response::Middleware
           def on_complete(env)
             raise Slack::Web::Api::Errors::TooManyRequestsError, env.response if env.status == 429
+            raise Slack::Web::Api::Errors::SlackError.new("Invalid JSON received from Slack API.", env.response) if !body.is_a?(Hash)
             return unless (body = env.body) && !body['ok']
 
             error_message =

--- a/spec/slack/web/faraday/response/raise_error_spec.rb
+++ b/spec/slack/web/faraday/response/raise_error_spec.rb
@@ -57,5 +57,15 @@ RSpec.describe Slack::Web::Faraday::Response::RaiseError do
         )
       end
     end
+
+    context 'with non-JSON response body' do
+      let(:body) do
+        '<!DOCTYPE html> <html lang="en"> <head> <meta charset="utf-8"> <title>Server Error | Slack</title> <meta name="author" content="Slack"> etc.'
+      end
+
+      it 'raises a Slack-domain error' do
+        expect { subject.on_complete(env) }.to raise_error(Slack::Web::Api::Errors::SlackError)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will raise an appropriately scoped exception with a descriptive message if the Slack API responds with non-JSON, i.e. an nginx 502/500 HTML error page.