### PR TITLE
fix inheriting from Faraday::Error in Faraday v0.17.1

### DIFF
--- a/lib/slack/web/api/errors/slack_error.rb
+++ b/lib/slack/web/api/errors/slack_error.rb
@@ -3,14 +3,7 @@ module Slack
   module Web
     module Api
       module Errors
-        class SlackError < ::Faraday::Error
-          attr_reader :response
-
-          def initialize(message, response = nil)
-            @response = response
-            super message
-          end
-        end
+        SlackError = Class.new(Faraday::Error)
       end
     end
   end

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Slack Web and RealTime API client.'
   s.add_dependency 'activesupport'
-  s.add_dependency 'faraday', '>= 0.9'
+  s.add_dependency 'faraday', '~> 0.17', '>= 0.17.1'
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'gli'
   s.add_dependency 'hashie'


### PR DESCRIPTION
Faraday changed the signature of an error class, as explained [here](https://github.com/slack-ruby/slack-ruby-client/pull/305#issuecomment-567227653).
This PR fixes inheriting from that error class and limits the Faraday version to `>= 0.17.1`.

I opened an [issue](https://github.com/lostisland/faraday/issues/1090) in the Faraday repo, let's wait for their response. Maybe they are open to reverting the change, then we could simple change the Faraday version requirement to `!= 0.17.1`.