### PR TITLE
don't allways fill events.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.15.1 (Next)
 
+* Your contribution here.
 * [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Don't allways fill events - [@pyama86](https://github.com/pyama86).
 
 ### 0.15.0 (2020/7/26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 0.15.1 (Next)
 
 * Your contribution here.
-* [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Don't allways fill events - [@pyama86](https://github.com/pyama86).
+* [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Fix: handle nil events - [@pyama86](https://github.com/pyama86).
 
 ### 0.15.0 (2020/7/26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 0.15.1 (Next)
 
-* Your contribution here.
+* [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Don't allways fill events - [@pyama86](https://github.com/pyama86).
 
 ### 0.15.0 (2020/7/26)
 

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -251,11 +251,11 @@ module Slack
       end
 
       def run_handlers(type, data)
-        if store.class.events
-          handlers = store.class.events[type.to_s]
-          handlers&.each do |handler|
-            store.instance_exec(data, &handler)
-          end
+        return unless store.class.events
+        handlers = store.class.events[type.to_s]
+        return unless handlers
+        handlers&.each do |handler|
+          store.instance_exec(data, &handler)
         end
       rescue StandardError => e
         logger.error("#{self}##{__method__}") { e }

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -251,9 +251,11 @@ module Slack
       end
 
       def run_handlers(type, data)
-        handlers = store.class.events[type.to_s]
-        handlers&.each do |handler|
-          store.instance_exec(data, &handler)
+        if store.class.events
+          handlers = store.class.events[type.to_s]
+          handlers&.each do |handler|
+            store.instance_exec(data, &handler)
+          end
         end
       rescue StandardError => e
         logger.error("#{self}##{__method__}") { e }

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -252,8 +252,10 @@ module Slack
 
       def run_handlers(type, data)
         return unless store.class.events
+
         handlers = store.class.events[type.to_s]
         return unless handlers
+
         handlers&.each do |handler|
           store.instance_exec(data, &handler)
         end

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -254,8 +254,6 @@ module Slack
         return unless store.class.events
 
         handlers = store.class.events[type.to_s]
-        return unless handlers
-
         handlers&.each do |handler|
           store.instance_exec(data, &handler)
         end

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -166,6 +166,36 @@ RSpec.describe Slack::RealTime::Client do # rubocop:disable Metrics/BlockLength
           expect(client.store.team.name).to eq 'New Team Name Inc.'
         end
       end
+
+      context 'subclassed' do
+        it 'runs event handlers' do
+          event = Slack::RealTime::Event.new(
+            'type' => 'team_rename',
+            'name' => 'New Team Name Inc.'
+          )
+          client.send(:dispatch, event)
+          expect(client.store.team.name).to eq 'New Team Name Inc.'
+        end
+      end
+
+      describe '#run_handlers' do
+        describe 'empty events' do
+          before do
+            client.store.class.events = []
+          end
+
+          it 'returns false when event is []' do
+            expect(client.send(:run_handlers, "example", {})).to be false
+          end
+        end
+
+        describe 'unknown events' do
+          it 'returns false when unknown event' do
+            expect(client.send(:run_handlers, "unknown", {})).to be false
+          end
+        end
+      end
+
     end
 
     describe '#start_async' do

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -185,17 +185,16 @@ RSpec.describe Slack::RealTime::Client do # rubocop:disable Metrics/BlockLength
           end
 
           it 'returns false when event is []' do
-            expect(client.send(:run_handlers, "example", {})).to be false
+            expect(client.send(:run_handlers, 'example', {})).to be false
           end
         end
 
         describe 'unknown events' do
           it 'returns false when unknown event' do
-            expect(client.send(:run_handlers, "unknown", {})).to be false
+            expect(client.send(:run_handlers, 'unknown', {})).to be false
           end
         end
       end
-
     end
 
     describe '#start_async' do

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -167,17 +167,6 @@ RSpec.describe Slack::RealTime::Client do # rubocop:disable Metrics/BlockLength
         end
       end
 
-      context 'subclassed' do
-        it 'runs event handlers' do
-          event = Slack::RealTime::Event.new(
-            'type' => 'team_rename',
-            'name' => 'New Team Name Inc.'
-          )
-          client.send(:dispatch, event)
-          expect(client.store.team.name).to eq 'New Team Name Inc.'
-        end
-      end
-
       describe '#run_handlers' do
         describe 'empty events' do
           before do

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -170,17 +170,16 @@ RSpec.describe Slack::RealTime::Client do # rubocop:disable Metrics/BlockLength
       describe '#run_handlers' do
         describe 'empty events' do
           before do
-            client.store.class.events = []
+            @e = client.store.class.events
+            client.store.class.events = nil
           end
 
-          it 'returns false when event is []' do
-            expect(client.send(:run_handlers, 'example', {})).to be false
+          after do
+            client.store.class.events = @e
           end
-        end
 
-        describe 'unknown events' do
-          it 'returns false when unknown event' do
-            expect(client.send(:run_handlers, 'unknown', {})).to be false
+          it 'returns false when event is nil' do
+            expect(client.send(:run_handlers, 'example', {})).to be nil
           end
         end
       end


### PR DESCRIPTION
Hi.
I notice this log which from `slack-ruby-bot` output.
```
#run_handlers: undefined method `[]' for nil:NilClass (NoMethodError)
away-from-keyboard-59cb64c5db-n76g7 away-from-keyboard-bot /usr/local/bundle/ruby/2.6.0/gems/slack-ruby-client-0.15.0/lib/slack/real_time/client.rb:254:in `run_handlers'
away-from-keyboard-59cb64c5db-n76g7 away-from-keyboard-bot /usr/local/bundle/ruby/2.6.0/gems/slack-ruby-client-0.15.0/lib/slack/real_time/client.rb:246:in `dispatch'
```
I don't always defined any hooks, so I add nil check before run_handler.

thanks!