### PR TITLE
Allow setting the faraday adapter for connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Fix: handle nil events - [@pyama86](https://github.com/pyama86).
 * [#339](https://github.com/slack-ruby/slack-ruby-client/pull/339): Fix: `channel_not_found` resolving channel IDs with 100+ channels - [@dblock](https://github.com/dblock).
-- [#340](https://github.com/slack-ruby/slack-ruby-client/pull/340): Added `adapter` configuration setting to change the `Faraday` HTTP adapter - [@watsonjon](https://github.com/watsonjon)
+- [#340](https://github.com/slack-ruby/slack-ruby-client/pull/340): Added `adapter` configuration setting to change the `Faraday` HTTP adapter - [@watsonjon](https://github.com/watsonjon).
 * Your contribution here.
 
 ### 0.15.0 (2020/7/26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Fix: handle nil events - [@pyama86](https://github.com/pyama86).
 * [#339](https://github.com/slack-ruby/slack-ruby-client/pull/339): Fix: `channel_not_found` resolving channel IDs with 100+ channels - [@dblock](https://github.com/dblock).
-- [#340](https://github.com/slack-ruby/slack-ruby-client/pull/340): Added `adapter` configuration setting to change the `Faraday` HTTP adapter - [@watsonjon](https://github.com/watsonjon).
+* [#340](https://github.com/slack-ruby/slack-ruby-client/pull/340): Added `adapter` configuration setting to change the `Faraday` HTTP adapter - [@watsonjon](https://github.com/watsonjon).
 * Your contribution here.
 
 ### 0.15.0 (2020/7/26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#336](https://github.com/slack-ruby/slack-ruby-client/pull/336): Fix: handle nil events - [@pyama86](https://github.com/pyama86).
 * [#339](https://github.com/slack-ruby/slack-ruby-client/pull/339): Fix: `channel_not_found` resolving channel IDs with 100+ channels - [@dblock](https://github.com/dblock).
+- [#340](https://github.com/slack-ruby/slack-ruby-client/pull/340): Added `adapter` configuration setting to change the `Faraday` HTTP adapter - [@watsonjon](https://github.com/watsonjon)
 * Your contribution here.
 
 ### 0.15.0 (2020/7/26)

--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ timeout             | Optional open/read timeout in seconds.
 open_timeout        | Optional connection open timeout in seconds.
 default_page_size   | Optional page size for paginated requests, default is _100_.
 default_max_retries | Optional number of retries for paginated requests, default is _100_.
+adapter             | Optional HTTP adapter to use, defaults to Faraday.default_adapter.
 
 You can also pass request options, including `timeout` and `open_timeout` into individual calls.
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ timeout             | Optional open/read timeout in seconds.
 open_timeout        | Optional connection open timeout in seconds.
 default_page_size   | Optional page size for paginated requests, default is _100_.
 default_max_retries | Optional number of retries for paginated requests, default is _100_.
-adapter             | Optional HTTP adapter to use, defaults to Faraday.default_adapter.
+adapter             | Optional HTTP adapter to use, defaults to `Faraday.default_adapter`.
 
 You can also pass request options, including `timeout` and `open_timeout` into individual calls.
 

--- a/lib/slack/web/config.rb
+++ b/lib/slack/web/config.rb
@@ -16,6 +16,7 @@ module Slack
         open_timeout
         default_page_size
         default_max_retries
+        adapter
       ].freeze
 
       attr_accessor(*Config::ATTRIBUTES)
@@ -32,6 +33,7 @@ module Slack
         self.open_timeout = nil
         self.default_page_size = 100
         self.default_max_retries = 100
+        self.adapter = ::Faraday.default_adapter
       end
     end
 

--- a/lib/slack/web/faraday/connection.rb
+++ b/lib/slack/web/faraday/connection.rb
@@ -29,7 +29,7 @@ module Slack
                 connection.use ::FaradayMiddleware::Mashify, mash_class: Slack::Messages::Message
                 connection.use ::FaradayMiddleware::ParseJson
                 connection.response :logger, logger if logger
-                connection.adapter ::Faraday.default_adapter
+                connection.adapter adapter
               end
             end
         end

--- a/spec/slack/web/client_spec.rb
+++ b/spec/slack/web/client_spec.rb
@@ -150,6 +150,47 @@ RSpec.describe Slack::Web::Client do
       end
     end
 
+    context 'adapter option' do
+      let(:adapter) { Faraday.default_adapter }
+      let(:adapter_class) { Faraday::Adapter::NetHttp }
+
+      before do
+        # ensure default adapter is set for this spec
+        Faraday.default_adapter = :net_http
+      end
+
+      context 'default adapter' do
+        describe '#initialize' do
+          it 'sets adapter' do
+            expect(client.adapter).to eq adapter
+          end
+          it 'creates a connection with an adapter' do
+            expect(client.send(:connection).adapter).to eq adapter_class
+          end
+        end
+      end
+
+      context 'non default adapter' do
+        let(:adapter) { :typhoeus }
+        let(:adapter_class) { Faraday::Adapter::Typhoeus }
+
+        before do
+          described_class.configure do |config|
+            config.adapter = adapter
+          end
+        end
+
+        describe '#initialize' do
+          it 'sets adapter' do
+            expect(client.adapter).to eq adapter
+          end
+          it 'creates a connection with an adapter' do
+            expect(client.send(:connection).adapter).to eq adapter_class
+          end
+        end
+      end
+    end
+
     context 'timeout options' do
       before do
         described_class.configure do |config|

--- a/spec/slack/web/client_spec.rb
+++ b/spec/slack/web/client_spec.rb
@@ -154,9 +154,12 @@ RSpec.describe Slack::Web::Client do
       let(:adapter) { Faraday.default_adapter }
       let(:adapter_class) { Faraday::Adapter::NetHttp }
 
-      before do
+      around do |ex|
+        previous_adapter = Faraday.default_adapter
         # ensure default adapter is set for this spec
         Faraday.default_adapter = :net_http
+        ex.run
+        Faraday.default_adapter = previous_adapter
       end
 
       context 'default adapter' do


### PR DESCRIPTION
Most of the time using the default Faraday adapter is fine, but _sometimes_ we want to allow that to differ. This will allow that to be set as part of the client configuration.