### PR TITLE
Add ruby-2.7.1 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: bundler
 rvm:
   - 2.5.3
   - 2.6.0
+  - 2.7.1
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
Super early look at https://github.com/slack-ruby/slack-ruby-client/issues/321