### PR TITLE
Drop redefined accessor methods

### DIFF
--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -20,7 +20,6 @@ module Slack
       attr_accessor :store
       attr_accessor :url
       attr_accessor(*Config::ATTRIBUTES)
-      attr_accessor :logger
 
       protected :store_class, :store_class=
 

--- a/lib/slack/real_time/config.rb
+++ b/lib/slack/real_time/config.rb
@@ -10,13 +10,14 @@ module Slack
         token
         websocket_ping
         websocket_proxy
+        concurrency
         start_method
         start_options
         store_class
         logger
       ].freeze
 
-      attr_accessor(*Config::ATTRIBUTES)
+      attr_accessor(*Config::ATTRIBUTES  - [:concurrency])
       attr_writer :concurrency
 
       def reset

--- a/lib/slack/real_time/config.rb
+++ b/lib/slack/real_time/config.rb
@@ -17,6 +17,7 @@ module Slack
       ].freeze
 
       attr_accessor(*Config::ATTRIBUTES)
+      attr_writer :concurrency
 
       def reset
         self.websocket_ping = 30

--- a/lib/slack/real_time/config.rb
+++ b/lib/slack/real_time/config.rb
@@ -10,7 +10,6 @@ module Slack
         token
         websocket_ping
         websocket_proxy
-        concurrency
         start_method
         start_options
         store_class

--- a/lib/slack/real_time/config.rb
+++ b/lib/slack/real_time/config.rb
@@ -17,7 +17,7 @@ module Slack
         logger
       ].freeze
 
-      attr_accessor(*Config::ATTRIBUTES  - [:concurrency])
+      attr_accessor(*Config::ATTRIBUTES - [:concurrency])
       attr_writer :concurrency
 
       def reset


### PR DESCRIPTION
This drops redefined accessor methods:
- `concurrency` is explicitly defined in `lib/slack/real_time/config.rb`
- `logger` in `lib/slack/real_time/client.rb` is defined by the line `attr_accessor(*Config::ATTRIBUTES)` above.

Resolves: #186