### PR TITLE
Rewind body after checking request signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [#348](https://github.com/slack-ruby/slack-ruby-client/pull/348): Added `admin_conversations_archive`, `admin_conversations_convertToPrivate`, `admin_conversations_create`, `admin_conversations_delete`, `admin_conversations_disconnectShared`, `admin_conversations_getConversationPrefs`, `admin_conversations_getTeams`, `admin_conversations_invite`, `admin_conversations_rename`, `admin_conversations_search`, `admin_conversations_setConversationPrefs`, `admin_conversations_unarchive`, `admin_conversations_ekm_listOriginalConnectedChannelInfo`, `admin_users_session_invalidate`, `apps_event_authorizations_list`, `conversations_mark`, `workflows_stepCompleted`, `workflows_stepFailed`, `workflows_updateStep` endpoints - [@wasabigeek](https://github.com/wasabigeek).
 * [#350](https://github.com/slack-ruby/slack-ruby-client/pull/350): Handle server errors such as timouts & non-json responses (see [Upgrading to 0.16.0](UPGRADING.md#upgrading-to--0160)) - [@ojab](https://github.com/ojab).
-* [](https://github.com/slack-ruby/slack-ruby-client/pull/): Rewind body after checking request signature - [@sunny](https://github.com/sunny).
+* [#354](https://github.com/slack-ruby/slack-ruby-client/pull/354): Rewind body after checking request signature - [@sunny](https://github.com/sunny).
 * Your contribution here.
 
 ### 0.15.1 (2020/9/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#348](https://github.com/slack-ruby/slack-ruby-client/pull/348): Added `admin_conversations_archive`, `admin_conversations_convertToPrivate`, `admin_conversations_create`, `admin_conversations_delete`, `admin_conversations_disconnectShared`, `admin_conversations_getConversationPrefs`, `admin_conversations_getTeams`, `admin_conversations_invite`, `admin_conversations_rename`, `admin_conversations_search`, `admin_conversations_setConversationPrefs`, `admin_conversations_unarchive`, `admin_conversations_ekm_listOriginalConnectedChannelInfo`, `admin_users_session_invalidate`, `apps_event_authorizations_list`, `conversations_mark`, `workflows_stepCompleted`, `workflows_stepFailed`, `workflows_updateStep` endpoints - [@wasabigeek](https://github.com/wasabigeek).
 * [#350](https://github.com/slack-ruby/slack-ruby-client/pull/350): Handle server errors such as timouts & non-json responses (see [Upgrading to 0.16.0](UPGRADING.md#upgrading-to--0160)) - [@ojab](https://github.com/ojab).
+* [](https://github.com/slack-ruby/slack-ruby-client/pull/): Rewind body after checking request signature - [@sunny](https://github.com/sunny).
 * Your contribution here.
 
 ### 0.15.1 (2020/9/3)

--- a/lib/slack/events/request.rb
+++ b/lib/slack/events/request.rb
@@ -35,7 +35,11 @@ module Slack
 
       # Request body.
       def body
-        @body ||= http_request.body.read
+        @body ||= begin
+          body = http_request.body.read
+          http_request.body.rewind
+          body
+        end
       end
 
       # Returns true if the signature coming from Slack has expired.

--- a/spec/slack/events/request_spec.rb
+++ b/spec/slack/events/request_spec.rb
@@ -26,9 +26,7 @@ RSpec.describe Slack::Events::Request do
         'X-Slack-Request-Timestamp' => timestamp,
         'X-Slack-Signature' => signature
       },
-      body: double(
-        read: body
-      )
+      body: StringIO.new(body)
     )
   end
 
@@ -42,6 +40,12 @@ RSpec.describe Slack::Events::Request do
     expect(request.timestamp).to eq timestamp
     expect(request.version).to eq 'v0'
   end
+
+  it 'rewinds the request body after reading it' do
+    expect(request.body).to eq body
+    expect(http_request.body.read).to eq body
+  end
+
   context 'time' do
     after do
       Timecop.return


### PR DESCRIPTION
## Before

Trying to read the request body after calling a Slack verification, returns an empty body:

```rb
Slack::Events::Request.new(request).verify!
request.body.read # => ""
```

This is because calling `request.body.read` on Rack requests causes the body’s StringIO to go to the end of the string.

## After

Therefore, to minimize surprise, we can rewind the body after reading it. After this fix, we get the following:

```rb
Slack::Events::Request.new(request).verify!
request.body.read # => "payload=%7B%22type%22%3A%22blo…"
```
