### PR TITLE
Handle non-JSON 500 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.16.1 (Next)
 
 * Your contribution here.
+* [#359](https://github.com/slack-ruby/slack-ruby-client/pull/359): Handle non-JSON 500 errors - [@agrobbin](https://github.com/agrobbin).
 
 ### 0.16.0 (2021/01/24)
 

--- a/lib/slack/web/faraday/connection.rb
+++ b/lib/slack/web/faraday/connection.rb
@@ -24,10 +24,10 @@ module Slack
               ::Faraday::Connection.new(endpoint, options) do |connection|
                 connection.use ::Faraday::Request::Multipart
                 connection.use ::Faraday::Request::UrlEncoded
-                connection.use ::Slack::Web::Faraday::Response::WrapError
                 connection.use ::Slack::Web::Faraday::Response::RaiseError
                 connection.use ::FaradayMiddleware::Mashify, mash_class: Slack::Messages::Message
                 connection.use ::FaradayMiddleware::ParseJson
+                connection.use ::Slack::Web::Faraday::Response::WrapError
                 connection.response :logger, logger if logger
                 connection.adapter adapter
               end

--- a/lib/slack/web/faraday/response/raise_error.rb
+++ b/lib/slack/web/faraday/response/raise_error.rb
@@ -23,12 +23,8 @@ module Slack
 
           def call(env)
             super
-          rescue Slack::Web::Api::Errors::SlackError, Slack::Web::Api::Errors::TooManyRequestsError
-            raise
           rescue ::Faraday::ParsingError
             raise Slack::Web::Api::Errors::ParsingError.new('parsing_error', env.response)
-          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed
-            raise Slack::Web::Api::Errors::TimeoutError.new('timeout_error', env.response)
           end
         end
       end

--- a/lib/slack/web/faraday/response/wrap_error.rb
+++ b/lib/slack/web/faraday/response/wrap_error.rb
@@ -3,13 +3,19 @@ module Slack
   module Web
     module Faraday
       module Response
-        class WrapError < ::Faraday::Response::RaiseError
+        class WrapError < ::Faraday::Response::Middleware
+          UNAVAILABLE_ERROR_STATUSES = (500..599).freeze
+
           def on_complete(env)
-            super
-          rescue Slack::Web::Api::Errors::SlackError
-            raise
-          rescue ::Faraday::ServerError
+            return unless UNAVAILABLE_ERROR_STATUSES.cover?(env.status)
+
             raise Slack::Web::Api::Errors::UnavailableError.new('unavailable_error', env.response)
+          end
+
+          def call(env)
+            super
+          rescue ::Faraday::TimeoutError, ::Faraday::ConnectionFailed
+            raise Slack::Web::Api::Errors::TimeoutError.new('timeout_error', env.response)
           end
         end
       end

--- a/spec/slack/web/client_spec.rb
+++ b/spec/slack/web/client_spec.rb
@@ -322,12 +322,22 @@ RSpec.describe Slack::Web::Client do
       end
 
       context '5xx response' do
-        before { stub_slack_request.to_return(status: 500, body: '{}') }
+        context 'with a JSON body' do
+          before { stub_slack_request.to_return(status: 500, body: '{}') }
 
-        it 'raises UnavailableError' do
-          expect { request }.to raise_error(Slack::Web::Api::Errors::UnavailableError).with_message('unavailable_error')
-          expect(exception.cause).to be_a(Faraday::ServerError)
-          expect(exception.response.status).to eq(500)
+          it 'raises UnavailableError' do
+            expect { request }.to raise_error(Slack::Web::Api::Errors::UnavailableError).with_message('unavailable_error')
+            expect(exception.response.status).to eq(500)
+          end
+        end
+
+        context 'with a HTML response' do
+          before { stub_slack_request.to_return(status: 500, body: '<html></html>') }
+
+          it 'raises UnavailableError' do
+            expect { request }.to raise_error(Slack::Web::Api::Errors::UnavailableError).with_message('unavailable_error')
+            expect(exception.response.status).to eq(500)
+          end
         end
       end
     end


### PR DESCRIPTION
Closes #358.

Consider this WebMock'd request, which is based on a real-world scenario we ran into when the Slack API was down:

```ruby
WebMock.stub_request(:post, 'https://slack.com/api/chat.postMessage').
  to_return(
    status: 500,
    body: <<~HTML
      <!DOCTYPE html>
      <html lang="en">
        <head>
          <meta charset="utf-8">
          <title>Server Error | Slack</title>
          <meta name="author" content="Slack">
        </head>
        <body></body>
      </html>
    HTML
  )
```

Before v0.16 (and #350), this raised a `Faraday::ParsingError` exception, and after those changes, it raises a `Slack::Web::Api::Errors::ParsingError` exception.

Looking further at the tests in #350, it appears while there is a test for [`status: 500, body: '{}'`](https://github.com/slack-ruby/slack-ruby-client/pull/350/files#diff-93bc39d0b2c86aa39fd163c47794a662f568ab6f7b3afa7d790d3e19d03f0dfcR324-R332), and there is a test for [`status: 200, body: '<html></html>`](https://github.com/slack-ruby/slack-ruby-client/pull/350/files#diff-93bc39d0b2c86aa39fd163c47794a662f568ab6f7b3afa7d790d3e19d03f0dfcR291-R300), there is no test for the combination of the 2.

This adds that test, and makes it pass!