### PR TITLE
Support rack requests in Slack::Events::Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#368](https://github.com/slack-ruby/slack-ruby-client/pull/368): Removed `admin_conversations_whitelist` and `admin_conversations_disconnectShared` - [@dblock](https://github.com/dblock).
 * [#359](https://github.com/slack-ruby/slack-ruby-client/pull/359): Handle non-JSON 500 errors - [@agrobbin](https://github.com/agrobbin).
 * [#360](https://github.com/slack-ruby/slack-ruby-client/pull/360): Remove faye-websocket from the concurrency detection error message - [@dblock](https://github.com/dblock).
+* [#369](https://github.com/slack-ruby/slack-ruby-client/pull/369): Support rack requests in `Slack::Events::Request` - [@wedgex](https://github.com/wedgex).
 * Your contribution here.
 
 ### 0.16.0 (2021/01/24)

--- a/lib/slack/events/request.rb
+++ b/lib/slack/events/request.rb
@@ -19,13 +19,13 @@ module Slack
 
       # Request timestamp.
       def timestamp
-        @timestamp ||= http_request.headers['X-Slack-Request-Timestamp']
+        @timestamp ||= http_request.get_header('HTTP_X_SLACK_REQUEST_TIMESTAMP')
       end
 
       # The signature is created by combining the signing secret with the body of the request
       # Slack is sending using a standard HMAC-SHA256 keyed hash.
       def signature
-        @signature ||= http_request.headers['X-Slack-Signature']
+        @signature ||= http_request.get_header('HTTP_X_SLACK_SIGNATURE')
       end
 
       # Signature version.

--- a/spec/slack/events/request_spec.rb
+++ b/spec/slack/events/request_spec.rb
@@ -21,13 +21,14 @@ RSpec.describe Slack::Events::Request do
     '"P7sFXA4o3HV2hTx4zb4zcQ9yrvuQs8pDh6EacOxmMRj0tJaXfQFF","type":"url_verification"}'
   end
   let(:http_request) do
-    double(
-      headers: {
-        'X-Slack-Request-Timestamp' => timestamp,
-        'X-Slack-Signature' => signature
-      },
+    request_double = double(
       body: StringIO.new(body)
     )
+
+    allow(request_double).to receive(:get_header).with('HTTP_X_SLACK_REQUEST_TIMESTAMP') { timestamp }
+    allow(request_double).to receive(:get_header).with('HTTP_X_SLACK_SIGNATURE') { signature }
+
+    request_double
   end
 
   after do


### PR DESCRIPTION
The `#headers` method on a request is implemented by Rails, so in
order for the event request class to support other rack based servers
we can instead look for the headers via `#get_header` or `#env`.

Since Rail's requests are an extension of rack requests this will
also work in a Rails app.

Also worth noting that rack's header's are prepended with `HTTP_`,
upcased, and treats `-` and `_` both as a `_`. Rails has some logic to
[obfuscate](https://github.com/rails/rails/blob/03cc18f5e7ba0364c6bbd7484fee16901c3be384/actionpack/lib/action_dispatch/http/headers.rb#L5-L23) this but technically supports both.