### PR TITLE
Enable the logging of the request body

### DIFF
--- a/lib/slack/web/faraday/connection.rb
+++ b/lib/slack/web/faraday/connection.rb
@@ -28,7 +28,7 @@ module Slack
                 connection.use ::FaradayMiddleware::Mashify, mash_class: Slack::Messages::Message
                 connection.use ::FaradayMiddleware::ParseJson
                 connection.use ::Slack::Web::Faraday::Response::WrapError
-                connection.response :logger, logger if logger
+                connection.response :logger, logger, bodies: true if logger
                 connection.adapter adapter
               end
             end


### PR DESCRIPTION
When debugging, I sometimes want to see the request body. I don't know if other people feel the same way. If you don't need it, please feel free to close this pull request.