### PR TITLE
Set a default filename so that Slack displays the preview correctly

### DIFF
--- a/lib/slack/web/api/endpoints/files.rb
+++ b/lib/slack/web/api/endpoints/files.rb
@@ -144,6 +144,7 @@ module Slack
           # @see https://api.slack.com/methods/files.upload
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.upload.json
           def files_upload(options = {})
+            options = options.merge(filename: 'file') if options[:file] && !options[:filename]
             post('files.upload', options)
           end
         end


### PR DESCRIPTION
Starting at 2021/05/05 05:30 UTC, Slack client no longer correctly displays previews of images when filename is not specified via slack-ruby-client gem. 

| Expectation | Reality |
| --- | --- |
| ![スクリーンショット 2021-05-07 21 52 06](https://user-images.githubusercontent.com/649961/117452278-878f7d00-af7e-11eb-9d05-bb15566f7680.png) | ![スクリーンショット 2021-05-07 21 47 43](https://user-images.githubusercontent.com/649961/117452345-9f670100-af7e-11eb-9613-6950af38a684.png) |


The reason of this behavior is that when a filename is not set to both `Faraday::UploadIO.new` and `Slack::Web::Client.new.files_upload`, multipart-post gem sets `local.path` as a filename. If `local.path` is specified as the filename, Slack will recognize the file as binary and will not show the image preview. In this pull request, I specify the default filename to avoid this behavior.

```
# An example of files.upload API
image = File.binread('image.png')
file = Faraday::UploadIO.new(StringIO.new(image), '_content_type_', 'can_specify_filename_here')
Slack::Web::Client.new.files_upload(channels: '#general', file: file, filename: 'can_specify_filename_here_too')
```

```
# The location where local.path is specified 
# https://github.com/socketry/multipart-post/blob/master/lib/multipart/post/composite_read_io.rb#L83
local_path = filename_or_io.respond_to?(:path) ? filename_or_io.path : "local.path"
```

----

The solution of specifying a default filename may be out of scope for slack-ruby-client gem. If you think so, please feel free to close this pull request.