### PR TITLE
gemspec: Drop unused directive test_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.18.0 (Next)
 
 * Your contribution here.
+* [#386](https://github.com/slack-ruby/slack-ruby-client/pull/386): Gemspec: drop unused `test_files` directive - [@olleolleolle](https://github.com/olleolleolle).
 * [#380](https://github.com/slack-ruby/slack-ruby-client/pull/380): Updates to server error classes and hierarchy - [@jmanian](https://github.com/jmanian).
 
 ### 0.17.0 (2021/03/07)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_rubygems_version = '>= 1.3.6'
   s.files = `git ls-files`.split("\n")
-  s.test_files = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
   s.homepage = 'http://github.com/slack-ruby/slack-ruby-client'
   s.licenses = ['MIT']


### PR DESCRIPTION
RubyGems.org does not use `test_files` for anything, and the directive can be removed from the gemspec.