### PR TITLE
Ensure token in VCR bodies.

### DIFF
--- a/spec/fixtures/slack/web/429_error.yml
+++ b/spec/fixtures/slack/web/429_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/auth.test
     body:
       encoding: UTF-8
-      string: ''
+      string: token=token
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/auth_test_error.yml
+++ b/spec/fixtures/slack/web/auth_test_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/auth.test
     body:
       encoding: UTF-8
-      string: ''
+      string: token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -75,81 +75,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"ok":false,"error":"not_authed"}'
-  recorded_at: Sat, 19 Jan 2019 21:25:48 GMT
-- request:
-    method: post
-    uri: https://slack.com/api/auth.test
-    body:
-      encoding: UTF-8
-      string: token=token
-    headers:
-      Accept:
-      - application/json; charset=utf-8
-      User-Agent:
-      - Slack Ruby Client/0.18.0
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Sat, 04 Dec 2021 20:13:20 GMT
-      Server:
-      - Apache
-      Access-Control-Allow-Origin:
-      - "*"
-      Referrer-Policy:
-      - no-referrer
-      X-Slack-Backend:
-      - r
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Access-Control-Allow-Headers:
-      - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
-        x-b3-sampled, x-b3-flags
-      Access-Control-Expose-Headers:
-      - x-slack-req-id, retry-after
-      X-Oauth-Scopes:
-      - identify,read,post,client,apps
-      Expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      Cache-Control:
-      - private, no-cache, no-store, must-revalidate
-      Pragma:
-      - no-cache
-      X-Xss-Protection:
-      - '0'
-      X-Content-Type-Options:
-      - nosniff
-      X-Slack-Req-Id:
-      - 180d1f56826e8dba46b2e5fb4fe74a78
-      Vary:
-      - Accept-Encoding
-      Content-Length:
-      - '165'
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Envoy-Upstream-Service-Time:
-      - '15'
-      X-Backend:
-      - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
-        main_control_with_overflow main_bedrock_control_with_overflow
-      X-Server:
-      - slack-www-hhvm-main-iad-gnko
-      X-Slack-Shared-Secret-Outcome:
-      - no-match
-      Via:
-      - envoy-www-iad-9e79, envoy-edge-canary-iad-e4we
-      X-Edge-Backend:
-      - envoy-www
-      X-Slack-Edge-Shared-Secret-Outcome:
-      - no-match
-    body:
-      encoding: UTF-8
-      string: '{"ok":true,"url":"https:\/\/dblockdotorg.slack.com\/","team":"dblock","user":"travis-ci","team_id":"T04KB5WQH","user_id":"U0J1GAHN1","bot_id":"B0J1L75DY","is_enterprise_install":false}'
   recorded_at: Sat, 19 Jan 2019 21:25:48 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/slack/web/auth_test_success.yml
+++ b/spec/fixtures/slack/web/auth_test_success.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/auth.test
     body:
       encoding: UTF-8
-      string: ''
+      string: token=token
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/conversations_info.yml
+++ b/spec/fixtures/slack/web/conversations_info.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.list
     body:
       encoding: UTF-8
-      string: limit=100
+      string: limit=100&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -85,7 +85,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.info
     body:
       encoding: UTF-8
-      string: channel=G0K7EV5A7
+      string: channel=G0K7EV5A7&token=token
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/conversations_setTopic.yml
+++ b/spec/fixtures/slack/web/conversations_setTopic.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.setTopic
     body:
       encoding: UTF-8
-      string: channel=C019CV63UTC&topic=new+topic
+      string: channel=C019CV63UTC&token=token&topic=new+topic
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/conversations_setTopic_one_page.yml
+++ b/spec/fixtures/slack/web/conversations_setTopic_one_page.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.list
     body:
       encoding: UTF-8
-      string: limit=100
+      string: limit=100&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -91,7 +91,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.setTopic
     body:
       encoding: UTF-8
-      string: channel=C018Y6VH39D&topic=new+topic
+      string: channel=C018Y6VH39D&token=token&topic=new+topic
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/conversations_setTopic_paginated.yml
+++ b/spec/fixtures/slack/web/conversations_setTopic_paginated.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.list
     body:
       encoding: UTF-8
-      string: limit=100
+      string: limit=100&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -91,7 +91,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.list
     body:
       encoding: UTF-8
-      string: cursor=dGVhbTpDMDE5Q1Y1RFdNUQ%3D%3D&limit=100
+      string: cursor=dGVhbTpDMDE5Q1Y1RFdNUQ%3D%3D&limit=100&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -170,7 +170,7 @@ http_interactions:
     uri: https://slack.com/api/conversations.setTopic
     body:
       encoding: UTF-8
-      string: channel=C019CV63UTC&topic=new+topic
+      string: channel=C019CV63UTC&token=token&topic=new+topic
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/paginated_users_list.yml
+++ b/spec/fixtures/slack/web/paginated_users_list.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: limit=5&presence=true
+      string: limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -89,7 +89,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: cursor=dXNlcjpVMDc1MThEVEw%3D&limit=5&presence=true
+      string: cursor=dXNlcjpVMDc1MThEVEw%3D&limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -173,7 +173,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: cursor=dXNlcjpVMEdQUjZLREo%3D&limit=5&presence=true
+      string: cursor=dXNlcjpVMEdQUjZLREo%3D&limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -262,7 +262,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: cursor=dXNlcjpVMEhMRlVaTEo%3D&limit=5&presence=true
+      string: cursor=dXNlcjpVMEhMRlVaTEo%3D&limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -349,7 +349,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: cursor=dXNlcjpVMFMwRzAyOEs%3D&limit=5&presence=true
+      string: cursor=dXNlcjpVMFMwRzAyOEs%3D&limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -435,7 +435,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: cursor=dXNlcjpVUEQ4WjJFM1Q%3D&limit=5&presence=true
+      string: cursor=dXNlcjpVUEQ4WjJFM1Q%3D&limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -518,7 +518,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: cursor=dXNlcjpVMDEyU0E5S1c0Ug%3D%3D&limit=5&presence=true
+      string: cursor=dXNlcjpVMDEyU0E5S1c0Ug%3D%3D&limit=5&presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/rtm_start.yml
+++ b/spec/fixtures/slack/web/rtm_start.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/rtm.start
     body:
       encoding: UTF-8
-      string: ''
+      string: token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -397,7 +397,7 @@ http_interactions:
     uri: https://slack.com/api/rtm.start
     body:
       encoding: UTF-8
-      string: simple_latest=true
+      string: simple_latest=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/users_info.yml
+++ b/spec/fixtures/slack/web/users_info.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: limit=100
+      string: limit=100&token=token
     headers:
       Accept:
       - application/json; charset=utf-8
@@ -133,7 +133,7 @@ http_interactions:
     uri: https://slack.com/api/users.info
     body:
       encoding: UTF-8
-      string: user=U07KECJ77
+      string: token=token&user=U07KECJ77
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/users_list.yml
+++ b/spec/fixtures/slack/web/users_list.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/users.list
     body:
       encoding: UTF-8
-      string: presence=true
+      string: presence=true&token=token
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/views_open_error.yml
+++ b/spec/fixtures/slack/web/views_open_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://slack.com/api/views.open
     body:
       encoding: UTF-8
-      string: trigger_id=trigger_id&view=%7B%7D
+      string: token=token&trigger_id=trigger_id&view=%7B%7D
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/slack/web/api/endpoints/custom_specs/auth_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/auth_spec.rb
@@ -5,19 +5,6 @@ RSpec.describe Slack::Web::Api::Endpoints::Auth do
   let(:client) { Slack::Web::Client.new }
 
   context 'without auth', vcr: { cassette_name: 'web/auth_test_error' } do
-    before do
-      Slack.configure do |config|
-        @token = config.token
-        config.token = nil
-      end
-    end
-
-    after do
-      Slack.configure do |config|
-        config.token = @token if @token
-      end
-    end
-
     it 'fails with an exception' do
       expect { client.auth_test }.to raise_error Slack::Web::Api::Errors::SlackError, 'not_authed'
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ Dir[File.join(File.dirname(__FILE__), 'support', '**/*.rb')].each do |file|
 end
 
 Slack.configure do |config|
-  config.token = ENV['SLACK_API_TOKEN']
+  config.token = 'token' # ENV['SLACK_API_TOKEN']
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Coming from https://github.com/slack-ruby/slack-ruby-client/pull/387#issuecomment-987245719

This should also fix CI on master that runs with an actual token for integ tests.