### PR TITLE
Force VCR to include headers in unmatched request error reports

### DIFF
--- a/spec/fixtures/slack/web/rtm_connect.yml
+++ b/spec/fixtures/slack/web/rtm_connect.yml
@@ -167,7 +167,7 @@ http_interactions:
     uri: https://slack.com/api/rtm.connect
     body:
       encoding: UTF-8
-      string: token
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/fixtures/slack/web/rtm_start.yml
+++ b/spec/fixtures/slack/web/rtm_start.yml
@@ -675,7 +675,7 @@ http_interactions:
     uri: https://slack.com/api/rtm.start
     body:
       encoding: UTF-8
-      string: token
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -6,7 +6,11 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/slack'
   config.hook_into :webmock
   config.configure_rspec_metadata!
-  config.filter_sensitive_data('<SLACK_API_TOKEN>') { ENV['SLACK_API_TOKEN'] }
+  if ENV['SLACK_API_TOKEN']
+    config.filter_sensitive_data('<SLACK_API_TOKEN>') do
+      ENV['SLACK_API_TOKEN']
+    end
+  end
   config.before_record do |i|
     i.response.body.force_encoding('UTF-8')
   end
@@ -18,4 +22,21 @@ VCR.configure do |config|
     match_requests_on: %i[method uri body client_headers]
     # record: :new_episodes
   }
+end
+
+module VCR
+  module Errors
+    class UnhandledHTTPRequestError
+      private
+
+      # Force unhandled HTTP error reports to include the headers
+      # for our custom matcher `client_headers`.
+      #
+      # This patch can be removed if https://github.com/vcr/vcr/issues/912
+      # is ever resolved.
+      def match_request_on_headers?
+        true
+      end
+    end
+  end
 end


### PR DESCRIPTION
Followup to https://github.com/slack-ruby/slack-ruby-client/pull/387#discussion_r764321209

Patches VCR unhandled HTTP request error reporter to always include headers, since we're using a custom header matcher.