### PR TITLE
Rub CI on Ruby 3.1.0 && update minor versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.5.3
-  - 2.6.0
-  - 2.7.1
-  - 3.0.2
+  - 2.5.9
+  - 2.6.7
+  - 2.7.4
+  - 3.0.3
+  - 3.1.0
   - ruby-head
   - jruby-head
 


### PR DESCRIPTION
This pull request makes CI runs on Ruby 3.1.0 since Ruby 3.1.0 has been released. Besides, it updates also lower versions.

ref: https://www.ruby-lang.org/en/downloads/releases/