### PR TITLE
Update `chat_update` method not to raise error with parameter which contains only `reply_broadcast`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#401](https://github.com/slack-ruby/slack-ruby-client/pull/401): Upgraded RuboCop to 1.26.0 - [@dblock](https://github.com/dblock).
 * [#401](https://github.com/slack-ruby/slack-ruby-client/pull/401): Added support for Ruby 3.1.1 - [@dblock](https://github.com/dblock).
 * [#405](https://github.com/slack-ruby/slack-ruby-client/pull/405): Added `admin_apps_requests_cancel`, `admin_users_unsupportedVersions_export`, `bookmarks_add`, `bookmarks_edit`, `bookmarks_list`, `bookmarks_remove` - [@dblock](https://github.com/dblock).
+* [#404](https://github.com/slack-ruby/slack-ruby-client/pull/404): Update `chat_update` method not to raise error with parameter which contains only `reply_broadcast` - [@colorbox](https://github.com/colorbox).
 * Your contribution here.
 
 ### 1.0.0 (2021/12/21)

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -287,7 +287,7 @@ module Slack
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.update.json
           def chat_update(options = {})
             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+            throw ArgumentError.new('Required arguments :text, :attachments, :blocks or :reply_broadcast missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil? && options[:reply_broadcast].nil?
             throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             # attachments must be passed as an encoded JSON string

--- a/lib/slack/web/api/patches/chat.1.patch
+++ b/lib/slack/web/api/patches/chat.1.patch
@@ -50,7 +50,7 @@ index d090ae2..50186d5 100644
            # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.update.json
            def chat_update(options = {})
              throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-+            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
++            throw ArgumentError.new('Required arguments :text, :attachments, :blocks or :reply_broadcast missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil? && options[:reply_broadcast].nil?
              throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
              options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
 +            # attachments must be passed as an encoded JSON string

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -154,9 +154,9 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
     end
 
     context 'text, attachment and blocks arguments' do
-      it 'requires text, attachments or blocks' do
+      it 'requires text, attachments, blocks or reply_broadcast' do
         expect { client.chat_update(channel: 'channel', ts: ts) }.to(
-          raise_error(ArgumentError, /Required arguments :text, :attachments or :blocks missing/)
+          raise_error(ArgumentError, /Required arguments :text, :attachments, :blocks or :reply_broadcast missing/)
         )
       end
       it 'only text' do
@@ -175,6 +175,12 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
         expect(client).to receive(:post).with('chat.update', hash_including(blocks: '[]'))
         expect do
           client.chat_update(channel: 'channel', ts: ts, blocks: [])
+        end.not_to raise_error
+      end
+      it 'only reply_broadcast' do
+        expect(client).to receive(:post).with('chat.update', hash_including(reply_broadcast: true))
+        expect do
+          client.chat_update(channel: 'channel', ts: ts, reply_broadcast: true)
         end.not_to raise_error
       end
       it 'all text, attachments and blocks' do


### PR DESCRIPTION
chat.update API accepts request which contain only one optional parameter `reply_broadcast`.
This PR update guard part of `chat_update` method to accept parameter which contains only `reply_broadcast`.

refs)
https://api.slack.com/methods/chat.update