### PR TITLE
Removes default values for Faraday's SSL settings `ca_file` and `ca_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 1.1.1 (Next)
+### 2.0.0 (Next)
 
+* [#416](https://github.com/slack-ruby/slack-ruby-client/pull/416): Removes default values for Faraday's SSL settings `ca_file` and `ca_path` - [@irphilli](https://github.com/irphilli).
 * Your contribution here.
 
 ### 1.1.0 (2022/06/05)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,25 @@
 Upgrading Slack-Ruby-Client
 ===========================
 
+### Upgrading to >= 2.0.0
+
+[#416](https://github.com/slack-ruby/slack-ruby-client/pull/416) Removes default values for Faraday's SSL settings `ca_file` and `ca_path`.
+
+If you previously relied on `OpenSSL::X509::DEFAULT_CERT_FILE` or `OpenSSL::X509::DEFAULT_CERT_DIR` to set these values you must now do so explicitly. E.g.:
+
+```ruby
+Slack::Web::Client.configure do |config|
+  config.ca_file = OpenSSL::X509::DEFAULT_CERT_FILE
+  config.ca_path = OpenSSL::X509::DEFAULT_CERT_DIR
+end
+```
+
+or
+
+```ruby
+client = Slack::Web::Client.new(ca_file: OpenSSL::X509::DEFAULT_CERT_FILE, ca_path: OpenSSL::X509::DEFAULT_CERT_DIR)
+```
+
 ### Upgrading to >= 1.0.0
 
 #### Deprecated Methods

--- a/lib/slack/version.rb
+++ b/lib/slack/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Slack
-  VERSION = '1.1.1'
+  VERSION = '2.0.0'
 end

--- a/lib/slack/web/config.rb
+++ b/lib/slack/web/config.rb
@@ -24,8 +24,8 @@ module Slack
       def reset
         self.endpoint = 'https://slack.com/api/'
         self.user_agent = "Slack Ruby Client/#{Slack::VERSION}"
-        self.ca_path = defined?(OpenSSL) ? OpenSSL::X509::DEFAULT_CERT_DIR : nil
-        self.ca_file = defined?(OpenSSL) ? OpenSSL::X509::DEFAULT_CERT_FILE : nil
+        self.ca_path = nil
+        self.ca_file = nil
         self.token = nil
         self.proxy = nil
         self.logger = nil


### PR DESCRIPTION
Fixes: #415 

Can alternatively just blanket default to `nil`, but this seems like this would be a bit less disruptive in case anyone was relying on the current defaults.