### PR TITLE
Raise rescuable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.0.0 (Next)
 
 * [#416](https://github.com/slack-ruby/slack-ruby-client/pull/416): Removes default values for Faraday's SSL settings `ca_file` and `ca_path` - [@irphilli](https://github.com/irphilli).
+* [#417](https://github.com/slack-ruby/slack-ruby-client/pull/417): Raise rescuable errors - [@zachahn](https://github.com/zachahn).
 * Your contribution here.
 
 ### 1.1.0 (2022/06/05)

--- a/lib/slack/real_time/api/message.rb
+++ b/lib/slack/real_time/api/message.rb
@@ -12,8 +12,9 @@ module Slack
         # @option options [Object] :text
         #   Text of the message to send. See below for an explanation of formatting.
         def message(options = {})
-          throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-          throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
+          raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+          raise ArgumentError, 'Required arguments :text missing' if options[:text].nil?
+
           send_json({ type: 'message', id: next_id }.merge(options))
         end
       end

--- a/lib/slack/real_time/api/typing.rb
+++ b/lib/slack/real_time/api/typing.rb
@@ -10,7 +10,8 @@ module Slack
         #   Channel to send message to. Can be a public channel, private group or IM channel.
         #   Can be an encoded ID, or a name.
         def typing(options = {})
-          throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+          raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+
           send_json({ type: 'typing', id: next_id }.merge(options))
         end
       end

--- a/lib/slack/web/api/endpoints/admin_analytics.rb
+++ b/lib/slack/web/api/endpoints/admin_analytics.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.analytics.getFile
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.analytics/admin.analytics.getFile.json
           def admin_analytics_getFile(options = {})
-            throw ArgumentError.new('Required arguments :type missing') if options[:type].nil?
+            raise ArgumentError, 'Required arguments :type missing' if options[:type].nil?
             post('admin.analytics.getFile', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_apps.rb
+++ b/lib/slack/web/api/endpoints/admin_apps.rb
@@ -35,7 +35,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.apps.clearResolution
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.apps/admin.apps.clearResolution.json
           def admin_apps_clearResolution(options = {})
-            throw ArgumentError.new('Required arguments :app_id missing') if options[:app_id].nil?
+            raise ArgumentError, 'Required arguments :app_id missing' if options[:app_id].nil?
             post('admin.apps.clearResolution', options)
           end
 
@@ -68,7 +68,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.apps.uninstall
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.apps/admin.apps.uninstall.json
           def admin_apps_uninstall(options = {})
-            throw ArgumentError.new('Required arguments :app_id missing') if options[:app_id].nil?
+            raise ArgumentError, 'Required arguments :app_id missing' if options[:app_id].nil?
             post('admin.apps.uninstall', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_apps_requests.rb
+++ b/lib/slack/web/api/endpoints/admin_apps_requests.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.apps.requests.cancel
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.apps.requests/admin.apps.requests.cancel.json
           def admin_apps_requests_cancel(options = {})
-            throw ArgumentError.new('Required arguments :request_id missing') if options[:request_id].nil?
+            raise ArgumentError, 'Required arguments :request_id missing' if options[:request_id].nil?
             post('admin.apps.requests.cancel', options)
           end
 

--- a/lib/slack/web/api/endpoints/admin_auth_policy.rb
+++ b/lib/slack/web/api/endpoints/admin_auth_policy.rb
@@ -18,9 +18,9 @@ module Slack
           # @see https://api.slack.com/methods/admin.auth.policy.assignEntities
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.auth.policy/admin.auth.policy.assignEntities.json
           def admin_auth_policy_assignEntities(options = {})
-            throw ArgumentError.new('Required arguments :entity_ids missing') if options[:entity_ids].nil?
-            throw ArgumentError.new('Required arguments :entity_type missing') if options[:entity_type].nil?
-            throw ArgumentError.new('Required arguments :policy_name missing') if options[:policy_name].nil?
+            raise ArgumentError, 'Required arguments :entity_ids missing' if options[:entity_ids].nil?
+            raise ArgumentError, 'Required arguments :entity_type missing' if options[:entity_type].nil?
+            raise ArgumentError, 'Required arguments :policy_name missing' if options[:policy_name].nil?
             post('admin.auth.policy.assignEntities', options)
           end
 
@@ -38,7 +38,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.auth.policy.getEntities
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.auth.policy/admin.auth.policy.getEntities.json
           def admin_auth_policy_getEntities(options = {})
-            throw ArgumentError.new('Required arguments :policy_name missing') if options[:policy_name].nil?
+            raise ArgumentError, 'Required arguments :policy_name missing' if options[:policy_name].nil?
             if block_given?
               Pagination::Cursor.new(self, :admin_auth_policy_getEntities, options).each do |page|
                 yield page
@@ -60,9 +60,9 @@ module Slack
           # @see https://api.slack.com/methods/admin.auth.policy.removeEntities
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.auth.policy/admin.auth.policy.removeEntities.json
           def admin_auth_policy_removeEntities(options = {})
-            throw ArgumentError.new('Required arguments :entity_ids missing') if options[:entity_ids].nil?
-            throw ArgumentError.new('Required arguments :entity_type missing') if options[:entity_type].nil?
-            throw ArgumentError.new('Required arguments :policy_name missing') if options[:policy_name].nil?
+            raise ArgumentError, 'Required arguments :entity_ids missing' if options[:entity_ids].nil?
+            raise ArgumentError, 'Required arguments :entity_type missing' if options[:entity_type].nil?
+            raise ArgumentError, 'Required arguments :policy_name missing' if options[:policy_name].nil?
             post('admin.auth.policy.removeEntities', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_barriers.rb
+++ b/lib/slack/web/api/endpoints/admin_barriers.rb
@@ -18,9 +18,9 @@ module Slack
           # @see https://api.slack.com/methods/admin.barriers.create
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.barriers/admin.barriers.create.json
           def admin_barriers_create(options = {})
-            throw ArgumentError.new('Required arguments :barriered_from_usergroup_ids missing') if options[:barriered_from_usergroup_ids].nil?
-            throw ArgumentError.new('Required arguments :primary_usergroup_id missing') if options[:primary_usergroup_id].nil?
-            throw ArgumentError.new('Required arguments :restricted_subjects missing') if options[:restricted_subjects].nil?
+            raise ArgumentError, 'Required arguments :barriered_from_usergroup_ids missing' if options[:barriered_from_usergroup_ids].nil?
+            raise ArgumentError, 'Required arguments :primary_usergroup_id missing' if options[:primary_usergroup_id].nil?
+            raise ArgumentError, 'Required arguments :restricted_subjects missing' if options[:restricted_subjects].nil?
             post('admin.barriers.create', options)
           end
 
@@ -32,7 +32,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.barriers.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.barriers/admin.barriers.delete.json
           def admin_barriers_delete(options = {})
-            throw ArgumentError.new('Required arguments :barrier_id missing') if options[:barrier_id].nil?
+            raise ArgumentError, 'Required arguments :barrier_id missing' if options[:barrier_id].nil?
             post('admin.barriers.delete', options)
           end
 
@@ -69,10 +69,10 @@ module Slack
           # @see https://api.slack.com/methods/admin.barriers.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.barriers/admin.barriers.update.json
           def admin_barriers_update(options = {})
-            throw ArgumentError.new('Required arguments :barrier_id missing') if options[:barrier_id].nil?
-            throw ArgumentError.new('Required arguments :barriered_from_usergroup_ids missing') if options[:barriered_from_usergroup_ids].nil?
-            throw ArgumentError.new('Required arguments :primary_usergroup_id missing') if options[:primary_usergroup_id].nil?
-            throw ArgumentError.new('Required arguments :restricted_subjects missing') if options[:restricted_subjects].nil?
+            raise ArgumentError, 'Required arguments :barrier_id missing' if options[:barrier_id].nil?
+            raise ArgumentError, 'Required arguments :barriered_from_usergroup_ids missing' if options[:barriered_from_usergroup_ids].nil?
+            raise ArgumentError, 'Required arguments :primary_usergroup_id missing' if options[:primary_usergroup_id].nil?
+            raise ArgumentError, 'Required arguments :restricted_subjects missing' if options[:restricted_subjects].nil?
             post('admin.barriers.update', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_conversations.rb
+++ b/lib/slack/web/api/endpoints/admin_conversations.rb
@@ -14,7 +14,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.archive
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.archive.json
           def admin_conversations_archive(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.archive', options)
           end
 
@@ -28,7 +28,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.convertToPrivate
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.convertToPrivate.json
           def admin_conversations_convertToPrivate(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.convertToPrivate', options)
           end
 
@@ -48,8 +48,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.create
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.create.json
           def admin_conversations_create(options = {})
-            throw ArgumentError.new('Required arguments :is_private missing') if options[:is_private].nil?
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :is_private missing' if options[:is_private].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             post('admin.conversations.create', options)
           end
 
@@ -61,7 +61,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.delete.json
           def admin_conversations_delete(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.delete', options)
           end
 
@@ -75,7 +75,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.disconnectShared
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.disconnectShared.json
           def admin_conversations_disconnectShared(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.disconnectShared', options)
           end
 
@@ -87,7 +87,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.getConversationPrefs
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.getConversationPrefs.json
           def admin_conversations_getConversationPrefs(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.getConversationPrefs', options)
           end
 
@@ -99,7 +99,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.getCustomRetention
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.getCustomRetention.json
           def admin_conversations_getCustomRetention(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.getCustomRetention', options)
           end
 
@@ -115,7 +115,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.getTeams
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.getTeams.json
           def admin_conversations_getTeams(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             if block_given?
               Pagination::Cursor.new(self, :admin_conversations_getTeams, options).each do |page|
                 yield page
@@ -135,8 +135,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.invite
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.invite.json
           def admin_conversations_invite(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :user_ids missing') if options[:user_ids].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :user_ids missing' if options[:user_ids].nil?
             post('admin.conversations.invite', options)
           end
 
@@ -148,7 +148,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.removeCustomRetention
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.removeCustomRetention.json
           def admin_conversations_removeCustomRetention(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.removeCustomRetention', options)
           end
 
@@ -162,8 +162,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.rename
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.rename.json
           def admin_conversations_rename(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             post('admin.conversations.rename', options)
           end
 
@@ -206,8 +206,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.setConversationPrefs
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.setConversationPrefs.json
           def admin_conversations_setConversationPrefs(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :prefs missing') if options[:prefs].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :prefs missing' if options[:prefs].nil?
             post('admin.conversations.setConversationPrefs', options)
           end
 
@@ -221,8 +221,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.setCustomRetention
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.setCustomRetention.json
           def admin_conversations_setCustomRetention(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :duration_days missing') if options[:duration_days].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :duration_days missing' if options[:duration_days].nil?
             post('admin.conversations.setCustomRetention', options)
           end
 
@@ -240,7 +240,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.setTeams
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.setTeams.json
           def admin_conversations_setTeams(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.setTeams', options)
           end
 
@@ -252,7 +252,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.unarchive
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations/admin.conversations.unarchive.json
           def admin_conversations_unarchive(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.unarchive', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_conversations_restrictAccess.rb
+++ b/lib/slack/web/api/endpoints/admin_conversations_restrictAccess.rb
@@ -18,8 +18,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.restrictAccess.addGroup
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations.restrictAccess/admin.conversations.restrictAccess.addGroup.json
           def admin_conversations_restrictAccess_addGroup(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :group_id missing') if options[:group_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :group_id missing' if options[:group_id].nil?
             post('admin.conversations.restrictAccess.addGroup', options)
           end
 
@@ -33,7 +33,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.restrictAccess.listGroups
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations.restrictAccess/admin.conversations.restrictAccess.listGroups.json
           def admin_conversations_restrictAccess_listGroups(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('admin.conversations.restrictAccess.listGroups', options)
           end
 
@@ -49,9 +49,9 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.restrictAccess.removeGroup
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations.restrictAccess/admin.conversations.restrictAccess.removeGroup.json
           def admin_conversations_restrictAccess_removeGroup(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :group_id missing') if options[:group_id].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :group_id missing' if options[:group_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.conversations.restrictAccess.removeGroup', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_conversations_whitelist.rb
+++ b/lib/slack/web/api/endpoints/admin_conversations_whitelist.rb
@@ -18,8 +18,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.whitelist.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations.whitelist/admin.conversations.whitelist.add.json
           def admin_conversations_whitelist_add(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :group_id missing') if options[:group_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :group_id missing' if options[:group_id].nil?
             logger.warn('admin.conversations.whitelist.add: This method is deprecated Alternative methods: .')
             post('admin.conversations.whitelist.add', options)
           end
@@ -34,7 +34,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.whitelist.listGroupsLinkedToChannel
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations.whitelist/admin.conversations.whitelist.listGroupsLinkedToChannel.json
           def admin_conversations_whitelist_listGroupsLinkedToChannel(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             logger.warn('admin.conversations.whitelist.listGroupsLinkedToChannel: This method is deprecated Alternative methods: .')
             post('admin.conversations.whitelist.listGroupsLinkedToChannel', options)
           end
@@ -51,9 +51,9 @@ module Slack
           # @see https://api.slack.com/methods/admin.conversations.whitelist.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.conversations.whitelist/admin.conversations.whitelist.remove.json
           def admin_conversations_whitelist_remove(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :group_id missing') if options[:group_id].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :group_id missing' if options[:group_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             logger.warn('admin.conversations.whitelist.remove: This method is deprecated Alternative methods: .')
             post('admin.conversations.whitelist.remove', options)
           end

--- a/lib/slack/web/api/endpoints/admin_emoji.rb
+++ b/lib/slack/web/api/endpoints/admin_emoji.rb
@@ -16,8 +16,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.emoji.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.emoji/admin.emoji.add.json
           def admin_emoji_add(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
-            throw ArgumentError.new('Required arguments :url missing') if options[:url].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
+            raise ArgumentError, 'Required arguments :url missing' if options[:url].nil?
             post('admin.emoji.add', options)
           end
 
@@ -31,8 +31,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.emoji.addAlias
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.emoji/admin.emoji.addAlias.json
           def admin_emoji_addAlias(options = {})
-            throw ArgumentError.new('Required arguments :alias_for missing') if options[:alias_for].nil?
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :alias_for missing' if options[:alias_for].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             post('admin.emoji.addAlias', options)
           end
 
@@ -63,7 +63,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.emoji.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.emoji/admin.emoji.remove.json
           def admin_emoji_remove(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             post('admin.emoji.remove', options)
           end
 
@@ -77,8 +77,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.emoji.rename
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.emoji/admin.emoji.rename.json
           def admin_emoji_rename(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
-            throw ArgumentError.new('Required arguments :new_name missing') if options[:new_name].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
+            raise ArgumentError, 'Required arguments :new_name missing' if options[:new_name].nil?
             post('admin.emoji.rename', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_inviteRequests.rb
+++ b/lib/slack/web/api/endpoints/admin_inviteRequests.rb
@@ -16,7 +16,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.inviteRequests.approve
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.inviteRequests/admin.inviteRequests.approve.json
           def admin_inviteRequests_approve(options = {})
-            throw ArgumentError.new('Required arguments :invite_request_id missing') if options[:invite_request_id].nil?
+            raise ArgumentError, 'Required arguments :invite_request_id missing' if options[:invite_request_id].nil?
             post('admin.inviteRequests.approve', options)
           end
 
@@ -30,7 +30,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.inviteRequests.deny
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.inviteRequests/admin.inviteRequests.deny.json
           def admin_inviteRequests_deny(options = {})
-            throw ArgumentError.new('Required arguments :invite_request_id missing') if options[:invite_request_id].nil?
+            raise ArgumentError, 'Required arguments :invite_request_id missing' if options[:invite_request_id].nil?
             post('admin.inviteRequests.deny', options)
           end
 

--- a/lib/slack/web/api/endpoints/admin_teams.rb
+++ b/lib/slack/web/api/endpoints/admin_teams.rb
@@ -20,8 +20,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.create
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams/admin.teams.create.json
           def admin_teams_create(options = {})
-            throw ArgumentError.new('Required arguments :team_domain missing') if options[:team_domain].nil?
-            throw ArgumentError.new('Required arguments :team_name missing') if options[:team_name].nil?
+            raise ArgumentError, 'Required arguments :team_domain missing' if options[:team_domain].nil?
+            raise ArgumentError, 'Required arguments :team_name missing' if options[:team_name].nil?
             post('admin.teams.create', options)
           end
 

--- a/lib/slack/web/api/endpoints/admin_teams_admins.rb
+++ b/lib/slack/web/api/endpoints/admin_teams_admins.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.admins.list
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.admins/admin.teams.admins.list.json
           def admin_teams_admins_list(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             if block_given?
               Pagination::Cursor.new(self, :admin_teams_admins_list, options).each do |page|
                 yield page

--- a/lib/slack/web/api/endpoints/admin_teams_owners.rb
+++ b/lib/slack/web/api/endpoints/admin_teams_owners.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.owners.list
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.owners/admin.teams.owners.list.json
           def admin_teams_owners_list(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             if block_given?
               Pagination::Cursor.new(self, :admin_teams_owners_list, options).each do |page|
                 yield page

--- a/lib/slack/web/api/endpoints/admin_teams_settings.rb
+++ b/lib/slack/web/api/endpoints/admin_teams_settings.rb
@@ -14,7 +14,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.settings.info
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.settings/admin.teams.settings.info.json
           def admin_teams_settings_info(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.teams.settings.info', options)
           end
 
@@ -28,8 +28,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.settings.setDefaultChannels
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.settings/admin.teams.settings.setDefaultChannels.json
           def admin_teams_settings_setDefaultChannels(options = {})
-            throw ArgumentError.new('Required arguments :channel_ids missing') if options[:channel_ids].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :channel_ids missing' if options[:channel_ids].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.teams.settings.setDefaultChannels', options)
           end
 
@@ -43,8 +43,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.settings.setDescription
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.settings/admin.teams.settings.setDescription.json
           def admin_teams_settings_setDescription(options = {})
-            throw ArgumentError.new('Required arguments :description missing') if options[:description].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :description missing' if options[:description].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.teams.settings.setDescription', options)
           end
 
@@ -58,8 +58,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.settings.setDiscoverability
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.settings/admin.teams.settings.setDiscoverability.json
           def admin_teams_settings_setDiscoverability(options = {})
-            throw ArgumentError.new('Required arguments :discoverability missing') if options[:discoverability].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :discoverability missing' if options[:discoverability].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.teams.settings.setDiscoverability', options)
           end
 
@@ -73,8 +73,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.settings.setIcon
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.settings/admin.teams.settings.setIcon.json
           def admin_teams_settings_setIcon(options = {})
-            throw ArgumentError.new('Required arguments :image_url missing') if options[:image_url].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :image_url missing' if options[:image_url].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.teams.settings.setIcon', options)
           end
 
@@ -88,8 +88,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.teams.settings.setName
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.teams.settings/admin.teams.settings.setName.json
           def admin_teams_settings_setName(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.teams.settings.setName', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_usergroups.rb
+++ b/lib/slack/web/api/endpoints/admin_usergroups.rb
@@ -18,8 +18,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.usergroups.addChannels
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.usergroups/admin.usergroups.addChannels.json
           def admin_usergroups_addChannels(options = {})
-            throw ArgumentError.new('Required arguments :channel_ids missing') if options[:channel_ids].nil?
-            throw ArgumentError.new('Required arguments :usergroup_id missing') if options[:usergroup_id].nil?
+            raise ArgumentError, 'Required arguments :channel_ids missing' if options[:channel_ids].nil?
+            raise ArgumentError, 'Required arguments :usergroup_id missing' if options[:usergroup_id].nil?
             post('admin.usergroups.addChannels', options)
           end
 
@@ -35,8 +35,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.usergroups.addTeams
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.usergroups/admin.usergroups.addTeams.json
           def admin_usergroups_addTeams(options = {})
-            throw ArgumentError.new('Required arguments :team_ids missing') if options[:team_ids].nil?
-            throw ArgumentError.new('Required arguments :usergroup_id missing') if options[:usergroup_id].nil?
+            raise ArgumentError, 'Required arguments :team_ids missing' if options[:team_ids].nil?
+            raise ArgumentError, 'Required arguments :usergroup_id missing' if options[:usergroup_id].nil?
             post('admin.usergroups.addTeams', options)
           end
 
@@ -52,7 +52,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.usergroups.listChannels
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.usergroups/admin.usergroups.listChannels.json
           def admin_usergroups_listChannels(options = {})
-            throw ArgumentError.new('Required arguments :usergroup_id missing') if options[:usergroup_id].nil?
+            raise ArgumentError, 'Required arguments :usergroup_id missing' if options[:usergroup_id].nil?
             post('admin.usergroups.listChannels', options)
           end
 
@@ -66,8 +66,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.usergroups.removeChannels
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.usergroups/admin.usergroups.removeChannels.json
           def admin_usergroups_removeChannels(options = {})
-            throw ArgumentError.new('Required arguments :channel_ids missing') if options[:channel_ids].nil?
-            throw ArgumentError.new('Required arguments :usergroup_id missing') if options[:usergroup_id].nil?
+            raise ArgumentError, 'Required arguments :channel_ids missing' if options[:channel_ids].nil?
+            raise ArgumentError, 'Required arguments :usergroup_id missing' if options[:usergroup_id].nil?
             post('admin.usergroups.removeChannels', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_users.rb
+++ b/lib/slack/web/api/endpoints/admin_users.rb
@@ -22,8 +22,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.assign
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.assign.json
           def admin_users_assign(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.assign', options)
           end
 
@@ -53,9 +53,9 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.invite
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.invite.json
           def admin_users_invite(options = {})
-            throw ArgumentError.new('Required arguments :channel_ids missing') if options[:channel_ids].nil?
-            throw ArgumentError.new('Required arguments :email missing') if options[:email].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :channel_ids missing' if options[:channel_ids].nil?
+            raise ArgumentError, 'Required arguments :email missing' if options[:email].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.users.invite', options)
           end
 
@@ -90,8 +90,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.remove.json
           def admin_users_remove(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.remove', options)
           end
 
@@ -105,8 +105,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.setAdmin
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.setAdmin.json
           def admin_users_setAdmin(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.setAdmin', options)
           end
 
@@ -122,8 +122,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.setExpiration
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.setExpiration.json
           def admin_users_setExpiration(options = {})
-            throw ArgumentError.new('Required arguments :expiration_ts missing') if options[:expiration_ts].nil?
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :expiration_ts missing' if options[:expiration_ts].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.setExpiration', options)
           end
 
@@ -137,8 +137,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.setOwner
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.setOwner.json
           def admin_users_setOwner(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.setOwner', options)
           end
 
@@ -152,8 +152,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.setRegular
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users/admin.users.setRegular.json
           def admin_users_setRegular(options = {})
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.setRegular', options)
           end
         end

--- a/lib/slack/web/api/endpoints/admin_users_session.rb
+++ b/lib/slack/web/api/endpoints/admin_users_session.rb
@@ -14,7 +14,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.session.clearSettings
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users.session/admin.users.session.clearSettings.json
           def admin_users_session_clearSettings(options = {})
-            throw ArgumentError.new('Required arguments :user_ids missing') if options[:user_ids].nil?
+            raise ArgumentError, 'Required arguments :user_ids missing' if options[:user_ids].nil?
             post('admin.users.session.clearSettings', options)
           end
 
@@ -26,7 +26,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.session.getSettings
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users.session/admin.users.session.getSettings.json
           def admin_users_session_getSettings(options = {})
-            throw ArgumentError.new('Required arguments :user_ids missing') if options[:user_ids].nil?
+            raise ArgumentError, 'Required arguments :user_ids missing' if options[:user_ids].nil?
             post('admin.users.session.getSettings', options)
           end
 
@@ -40,8 +40,8 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.session.invalidate
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users.session/admin.users.session.invalidate.json
           def admin_users_session_invalidate(options = {})
-            throw ArgumentError.new('Required arguments :session_id missing') if options[:session_id].nil?
-            throw ArgumentError.new('Required arguments :team_id missing') if options[:team_id].nil?
+            raise ArgumentError, 'Required arguments :session_id missing' if options[:session_id].nil?
+            raise ArgumentError, 'Required arguments :team_id missing' if options[:team_id].nil?
             post('admin.users.session.invalidate', options)
           end
 
@@ -80,7 +80,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.session.reset
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users.session/admin.users.session.reset.json
           def admin_users_session_reset(options = {})
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
             post('admin.users.session.reset', options)
           end
 
@@ -96,7 +96,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.session.resetBulk
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users.session/admin.users.session.resetBulk.json
           def admin_users_session_resetBulk(options = {})
-            throw ArgumentError.new('Required arguments :user_ids missing') if options[:user_ids].nil?
+            raise ArgumentError, 'Required arguments :user_ids missing' if options[:user_ids].nil?
             post('admin.users.session.resetBulk', options)
           end
 
@@ -112,7 +112,7 @@ module Slack
           # @see https://api.slack.com/methods/admin.users.session.setSettings
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/admin.users.session/admin.users.session.setSettings.json
           def admin_users_session_setSettings(options = {})
-            throw ArgumentError.new('Required arguments :user_ids missing') if options[:user_ids].nil?
+            raise ArgumentError, 'Required arguments :user_ids missing' if options[:user_ids].nil?
             post('admin.users.session.setSettings', options)
           end
         end

--- a/lib/slack/web/api/endpoints/apps.rb
+++ b/lib/slack/web/api/endpoints/apps.rb
@@ -16,8 +16,8 @@ module Slack
           # @see https://api.slack.com/methods/apps.uninstall
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps/apps.uninstall.json
           def apps_uninstall(options = {})
-            throw ArgumentError.new('Required arguments :client_id missing') if options[:client_id].nil?
-            throw ArgumentError.new('Required arguments :client_secret missing') if options[:client_secret].nil?
+            raise ArgumentError, 'Required arguments :client_id missing' if options[:client_id].nil?
+            raise ArgumentError, 'Required arguments :client_secret missing' if options[:client_secret].nil?
             post('apps.uninstall', options)
           end
         end

--- a/lib/slack/web/api/endpoints/apps_event_authorizations.rb
+++ b/lib/slack/web/api/endpoints/apps_event_authorizations.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/apps.event.authorizations.list
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.event.authorizations/apps.event.authorizations.list.json
           def apps_event_authorizations_list(options = {})
-            throw ArgumentError.new('Required arguments :event_context missing') if options[:event_context].nil?
+            raise ArgumentError, 'Required arguments :event_context missing' if options[:event_context].nil?
             if block_given?
               Pagination::Cursor.new(self, :apps_event_authorizations_list, options).each do |page|
                 yield page

--- a/lib/slack/web/api/endpoints/apps_manifest.rb
+++ b/lib/slack/web/api/endpoints/apps_manifest.rb
@@ -14,7 +14,7 @@ module Slack
           # @see https://api.slack.com/methods/apps.manifest.create
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.manifest/apps.manifest.create.json
           def apps_manifest_create(options = {})
-            throw ArgumentError.new('Required arguments :manifest missing') if options[:manifest].nil?
+            raise ArgumentError, 'Required arguments :manifest missing' if options[:manifest].nil?
             post('apps.manifest.create', options)
           end
 
@@ -26,7 +26,7 @@ module Slack
           # @see https://api.slack.com/methods/apps.manifest.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.manifest/apps.manifest.delete.json
           def apps_manifest_delete(options = {})
-            throw ArgumentError.new('Required arguments :app_id missing') if options[:app_id].nil?
+            raise ArgumentError, 'Required arguments :app_id missing' if options[:app_id].nil?
             post('apps.manifest.delete', options)
           end
 
@@ -38,7 +38,7 @@ module Slack
           # @see https://api.slack.com/methods/apps.manifest.export
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.manifest/apps.manifest.export.json
           def apps_manifest_export(options = {})
-            throw ArgumentError.new('Required arguments :app_id missing') if options[:app_id].nil?
+            raise ArgumentError, 'Required arguments :app_id missing' if options[:app_id].nil?
             post('apps.manifest.export', options)
           end
 
@@ -52,8 +52,8 @@ module Slack
           # @see https://api.slack.com/methods/apps.manifest.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.manifest/apps.manifest.update.json
           def apps_manifest_update(options = {})
-            throw ArgumentError.new('Required arguments :app_id missing') if options[:app_id].nil?
-            throw ArgumentError.new('Required arguments :manifest missing') if options[:manifest].nil?
+            raise ArgumentError, 'Required arguments :app_id missing' if options[:app_id].nil?
+            raise ArgumentError, 'Required arguments :manifest missing' if options[:manifest].nil?
             post('apps.manifest.update', options)
           end
 
@@ -67,7 +67,7 @@ module Slack
           # @see https://api.slack.com/methods/apps.manifest.validate
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.manifest/apps.manifest.validate.json
           def apps_manifest_validate(options = {})
-            throw ArgumentError.new('Required arguments :manifest missing') if options[:manifest].nil?
+            raise ArgumentError, 'Required arguments :manifest missing' if options[:manifest].nil?
             post('apps.manifest.validate', options)
           end
         end

--- a/lib/slack/web/api/endpoints/apps_permissions.rb
+++ b/lib/slack/web/api/endpoints/apps_permissions.rb
@@ -25,8 +25,8 @@ module Slack
           # @see https://api.slack.com/methods/apps.permissions.request
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.permissions/apps.permissions.request.json
           def apps_permissions_request(options = {})
-            throw ArgumentError.new('Required arguments :scopes missing') if options[:scopes].nil?
-            throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
+            raise ArgumentError, 'Required arguments :scopes missing' if options[:scopes].nil?
+            raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
             post('apps.permissions.request', options)
           end
         end

--- a/lib/slack/web/api/endpoints/apps_permissions_users.rb
+++ b/lib/slack/web/api/endpoints/apps_permissions_users.rb
@@ -37,9 +37,9 @@ module Slack
           # @see https://api.slack.com/methods/apps.permissions.users.request
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/apps.permissions.users/apps.permissions.users.request.json
           def apps_permissions_users_request(options = {})
-            throw ArgumentError.new('Required arguments :scopes missing') if options[:scopes].nil?
-            throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
-            throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+            raise ArgumentError, 'Required arguments :scopes missing' if options[:scopes].nil?
+            raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
+            raise ArgumentError, 'Required arguments :user missing' if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             post('apps.permissions.users.request', options)
           end

--- a/lib/slack/web/api/endpoints/bookmarks.rb
+++ b/lib/slack/web/api/endpoints/bookmarks.rb
@@ -26,9 +26,9 @@ module Slack
           # @see https://api.slack.com/methods/bookmarks.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/bookmarks/bookmarks.add.json
           def bookmarks_add(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
-            throw ArgumentError.new('Required arguments :title missing') if options[:title].nil?
-            throw ArgumentError.new('Required arguments :type missing') if options[:type].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :title missing' if options[:title].nil?
+            raise ArgumentError, 'Required arguments :type missing' if options[:type].nil?
             post('bookmarks.add', options)
           end
 
@@ -48,8 +48,8 @@ module Slack
           # @see https://api.slack.com/methods/bookmarks.edit
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/bookmarks/bookmarks.edit.json
           def bookmarks_edit(options = {})
-            throw ArgumentError.new('Required arguments :bookmark_id missing') if options[:bookmark_id].nil?
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :bookmark_id missing' if options[:bookmark_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('bookmarks.edit', options)
           end
 
@@ -61,7 +61,7 @@ module Slack
           # @see https://api.slack.com/methods/bookmarks.list
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/bookmarks/bookmarks.list.json
           def bookmarks_list(options = {})
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('bookmarks.list', options)
           end
 
@@ -75,8 +75,8 @@ module Slack
           # @see https://api.slack.com/methods/bookmarks.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/bookmarks/bookmarks.remove.json
           def bookmarks_remove(options = {})
-            throw ArgumentError.new('Required arguments :bookmark_id missing') if options[:bookmark_id].nil?
-            throw ArgumentError.new('Required arguments :channel_id missing') if options[:channel_id].nil?
+            raise ArgumentError, 'Required arguments :bookmark_id missing' if options[:bookmark_id].nil?
+            raise ArgumentError, 'Required arguments :channel_id missing' if options[:channel_id].nil?
             post('bookmarks.remove', options)
           end
         end

--- a/lib/slack/web/api/endpoints/calls.rb
+++ b/lib/slack/web/api/endpoints/calls.rb
@@ -28,8 +28,8 @@ module Slack
           # @see https://api.slack.com/methods/calls.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/calls/calls.add.json
           def calls_add(options = {})
-            throw ArgumentError.new('Required arguments :external_unique_id missing') if options[:external_unique_id].nil?
-            throw ArgumentError.new('Required arguments :join_url missing') if options[:join_url].nil?
+            raise ArgumentError, 'Required arguments :external_unique_id missing' if options[:external_unique_id].nil?
+            raise ArgumentError, 'Required arguments :join_url missing' if options[:join_url].nil?
             post('calls.add', options)
           end
 
@@ -43,7 +43,7 @@ module Slack
           # @see https://api.slack.com/methods/calls.end
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/calls/calls.end.json
           def calls_end(options = {})
-            throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
+            raise ArgumentError, 'Required arguments :id missing' if options[:id].nil?
             post('calls.end', options)
           end
 
@@ -55,7 +55,7 @@ module Slack
           # @see https://api.slack.com/methods/calls.info
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/calls/calls.info.json
           def calls_info(options = {})
-            throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
+            raise ArgumentError, 'Required arguments :id missing' if options[:id].nil?
             post('calls.info', options)
           end
 
@@ -73,7 +73,7 @@ module Slack
           # @see https://api.slack.com/methods/calls.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/calls/calls.update.json
           def calls_update(options = {})
-            throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
+            raise ArgumentError, 'Required arguments :id missing' if options[:id].nil?
             post('calls.update', options)
           end
         end

--- a/lib/slack/web/api/endpoints/calls_participants.rb
+++ b/lib/slack/web/api/endpoints/calls_participants.rb
@@ -16,8 +16,8 @@ module Slack
           # @see https://api.slack.com/methods/calls.participants.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/calls.participants/calls.participants.add.json
           def calls_participants_add(options = {})
-            throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
-            throw ArgumentError.new('Required arguments :users missing') if options[:users].nil?
+            raise ArgumentError, 'Required arguments :id missing' if options[:id].nil?
+            raise ArgumentError, 'Required arguments :users missing' if options[:users].nil?
             post('calls.participants.add', options)
           end
 
@@ -31,8 +31,8 @@ module Slack
           # @see https://api.slack.com/methods/calls.participants.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/calls.participants/calls.participants.remove.json
           def calls_participants_remove(options = {})
-            throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
-            throw ArgumentError.new('Required arguments :users missing') if options[:users].nil?
+            raise ArgumentError, 'Required arguments :id missing' if options[:id].nil?
+            raise ArgumentError, 'Required arguments :users missing' if options[:users].nil?
             post('calls.participants.remove', options)
           end
         end

--- a/lib/slack/web/api/endpoints/channels.rb
+++ b/lib/slack/web/api/endpoints/channels.rb
@@ -13,7 +13,7 @@ module Slack
           #   Channel to delete.
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/channels/channels.delete.json
           def channels_delete(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             logger.warn('The channels.delete method is undocumented.')
             post('channels.delete', options)

--- a/lib/slack/web/api/endpoints/chat.rb
+++ b/lib/slack/web/api/endpoints/chat.rb
@@ -17,8 +17,8 @@ module Slack
           #   Additional parameters provided to the slash command.
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/chat/chat.command.json
           def chat_command(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :command missing') if options[:command].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :command missing' if options[:command].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             logger.warn('The chat.command method is undocumented.')
             post('chat.command', options)
@@ -36,8 +36,8 @@ module Slack
           # @see https://api.slack.com/methods/chat.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.delete.json
           def chat_delete(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :ts missing' if options[:ts].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('chat.delete', options)
           end
@@ -54,8 +54,8 @@ module Slack
           # @see https://api.slack.com/methods/chat.deleteScheduledMessage
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.deleteScheduledMessage.json
           def chat_deleteScheduledMessage(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :scheduled_message_id missing') if options[:scheduled_message_id].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :scheduled_message_id missing' if options[:scheduled_message_id].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('chat.deleteScheduledMessage', options)
           end
@@ -70,8 +70,8 @@ module Slack
           # @see https://api.slack.com/methods/chat.getPermalink
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.getPermalink.json
           def chat_getPermalink(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :message_ts missing') if options[:message_ts].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :message_ts missing' if options[:message_ts].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('chat.getPermalink', options)
           end
@@ -86,8 +86,8 @@ module Slack
           # @see https://api.slack.com/methods/chat.meMessage
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.meMessage.json
           def chat_meMessage(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :text missing' if options[:text].nil?
             post('chat.meMessage', options)
           end
 
@@ -121,9 +121,9 @@ module Slack
           # @see https://api.slack.com/methods/chat.postEphemeral
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postEphemeral.json
           def chat_postEphemeral(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
-            throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :text, :attachments or :blocks missing' if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+            raise ArgumentError, 'Required arguments :user missing' if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
@@ -176,8 +176,8 @@ module Slack
           # @see https://api.slack.com/methods/chat.postMessage
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postMessage.json
           def chat_postMessage(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :text, :attachments or :blocks missing' if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)
               attachments = options[:attachments]
@@ -223,9 +223,9 @@ module Slack
           # @see https://api.slack.com/methods/chat.scheduleMessage
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.scheduleMessage.json
           def chat_scheduleMessage(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :post_at missing') if options[:post_at].nil?
-            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :post_at missing' if options[:post_at].nil?
+            raise ArgumentError, 'Required arguments :text missing' if options[:text].nil?
             post('chat.scheduleMessage', options)
           end
 
@@ -253,9 +253,9 @@ module Slack
           # @see https://api.slack.com/methods/chat.unfurl
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.unfurl.json
           def chat_unfurl(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
-            throw ArgumentError.new('Required arguments :unfurls missing') if options[:unfurls].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :ts missing' if options[:ts].nil?
+            raise ArgumentError, 'Required arguments :unfurls missing' if options[:unfurls].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('chat.unfurl', options)
           end
@@ -286,9 +286,9 @@ module Slack
           # @see https://api.slack.com/methods/chat.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.update.json
           def chat_update(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :text, :attachments, :blocks or :reply_broadcast missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil? && options[:reply_broadcast].nil?
-            throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :text, :attachments, :blocks or :reply_broadcast missing' if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil? && options[:reply_broadcast].nil?
+            raise ArgumentError, 'Required arguments :ts missing' if options[:ts].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             # attachments must be passed as an encoded JSON string
             if options.key?(:attachments)

--- a/lib/slack/web/api/endpoints/conversations.rb
+++ b/lib/slack/web/api/endpoints/conversations.rb
@@ -24,7 +24,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.acceptSharedInvite
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.acceptSharedInvite.json
           def conversations_acceptSharedInvite(options = {})
-            throw ArgumentError.new('Required arguments :channel_name missing') if options[:channel_name].nil?
+            raise ArgumentError, 'Required arguments :channel_name missing' if options[:channel_name].nil?
             post('conversations.acceptSharedInvite', options)
           end
 
@@ -38,7 +38,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.approveSharedInvite
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.approveSharedInvite.json
           def conversations_approveSharedInvite(options = {})
-            throw ArgumentError.new('Required arguments :invite_id missing') if options[:invite_id].nil?
+            raise ArgumentError, 'Required arguments :invite_id missing' if options[:invite_id].nil?
             post('conversations.approveSharedInvite', options)
           end
 
@@ -50,7 +50,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.archive
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.archive.json
           def conversations_archive(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.archive', options)
           end
@@ -63,7 +63,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.close
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.close.json
           def conversations_close(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.close', options)
           end
@@ -80,7 +80,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.create
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.create.json
           def conversations_create(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             post('conversations.create', options)
           end
 
@@ -94,7 +94,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.declineSharedInvite
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.declineSharedInvite.json
           def conversations_declineSharedInvite(options = {})
-            throw ArgumentError.new('Required arguments :invite_id missing') if options[:invite_id].nil?
+            raise ArgumentError, 'Required arguments :invite_id missing' if options[:invite_id].nil?
             post('conversations.declineSharedInvite', options)
           end
 
@@ -116,7 +116,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.history
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.history.json
           def conversations_history(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             if block_given?
               Pagination::Cursor.new(self, :conversations_history, options).each do |page|
@@ -139,7 +139,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.info
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.info.json
           def conversations_info(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.info', options)
           end
@@ -154,8 +154,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.invite
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.invite.json
           def conversations_invite(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :users missing') if options[:users].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :users missing' if options[:users].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.invite', options)
           end
@@ -174,7 +174,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.inviteShared
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.inviteShared.json
           def conversations_inviteShared(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.inviteShared', options)
           end
@@ -187,7 +187,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.join
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.join.json
           def conversations_join(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.join', options)
           end
@@ -202,8 +202,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.kick
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.kick.json
           def conversations_kick(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :user missing' if options[:user].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             post('conversations.kick', options)
@@ -217,7 +217,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.leave
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.leave.json
           def conversations_leave(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.leave', options)
           end
@@ -276,8 +276,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.mark
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.mark.json
           def conversations_mark(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :ts missing' if options[:ts].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.mark', options)
           end
@@ -294,7 +294,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.members
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.members.json
           def conversations_members(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             if block_given?
               Pagination::Cursor.new(self, :conversations_members, options).each do |page|
@@ -333,8 +333,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.rename
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.rename.json
           def conversations_rename(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.rename', options)
           end
@@ -359,8 +359,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.replies
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.replies.json
           def conversations_replies(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :ts missing' if options[:ts].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             if block_given?
               Pagination::Cursor.new(self, :conversations_replies, options).each do |page|
@@ -381,8 +381,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.setPurpose
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.setPurpose.json
           def conversations_setPurpose(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :purpose missing') if options[:purpose].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :purpose missing' if options[:purpose].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.setPurpose', options)
           end
@@ -397,8 +397,8 @@ module Slack
           # @see https://api.slack.com/methods/conversations.setTopic
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.setTopic.json
           def conversations_setTopic(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :topic missing') if options[:topic].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :topic missing' if options[:topic].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.setTopic', options)
           end
@@ -411,7 +411,7 @@ module Slack
           # @see https://api.slack.com/methods/conversations.unarchive
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/conversations/conversations.unarchive.json
           def conversations_unarchive(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('conversations.unarchive', options)
           end

--- a/lib/slack/web/api/endpoints/dialog.rb
+++ b/lib/slack/web/api/endpoints/dialog.rb
@@ -16,8 +16,8 @@ module Slack
           # @see https://api.slack.com/methods/dialog.open
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/dialog/dialog.open.json
           def dialog_open(options = {})
-            throw ArgumentError.new('Required arguments :dialog missing') if options[:dialog].nil?
-            throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
+            raise ArgumentError, 'Required arguments :dialog missing' if options[:dialog].nil?
+            raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
             # dialog must be passed as an encoded JSON string
             if options.key?(:dialog)
               dialog = options[:dialog]

--- a/lib/slack/web/api/endpoints/dnd.rb
+++ b/lib/slack/web/api/endpoints/dnd.rb
@@ -59,7 +59,7 @@ module Slack
           # @see https://api.slack.com/methods/dnd.teamInfo
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/dnd/dnd.teamInfo.json
           def dnd_teamInfo(options = {})
-            throw ArgumentError.new('Required arguments :users missing') if options[:users].nil?
+            raise ArgumentError, 'Required arguments :users missing' if options[:users].nil?
             post('dnd.teamInfo', options)
           end
         end

--- a/lib/slack/web/api/endpoints/files.rb
+++ b/lib/slack/web/api/endpoints/files.rb
@@ -14,7 +14,7 @@ module Slack
           # @see https://api.slack.com/methods/files.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.delete.json
           def files_delete(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
             post('files.delete', options)
           end
 
@@ -29,8 +29,8 @@ module Slack
           #   New filetype of the file. See https://api.slack.com/types/file#file_types for a list of all supported types.
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/files/files.edit.json
           def files_edit(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
-            throw ArgumentError.new('Required arguments :title missing') if options[:title].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
+            raise ArgumentError, 'Required arguments :title missing' if options[:title].nil?
             logger.warn('The files.edit method is undocumented.')
             post('files.edit', options)
           end
@@ -47,7 +47,7 @@ module Slack
           # @see https://api.slack.com/methods/files.info
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.info.json
           def files_info(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
             if block_given?
               Pagination::Cursor.new(self, :files_info, options).each do |page|
                 yield page
@@ -92,7 +92,7 @@ module Slack
           # @see https://api.slack.com/methods/files.revokePublicURL
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.revokePublicURL.json
           def files_revokePublicURL(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
             post('files.revokePublicURL', options)
           end
 
@@ -105,8 +105,8 @@ module Slack
           #   Channel to share the file in. Works with both public (channel ID) and private channels (group ID).
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/files/files.share.json
           def files_share(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             logger.warn('The files.share method is undocumented.')
             post('files.share', options)
@@ -120,7 +120,7 @@ module Slack
           # @see https://api.slack.com/methods/files.sharedPublicURL
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.sharedPublicURL.json
           def files_sharedPublicURL(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
             post('files.sharedPublicURL', options)
           end
 

--- a/lib/slack/web/api/endpoints/files_comments.rb
+++ b/lib/slack/web/api/endpoints/files_comments.rb
@@ -16,8 +16,8 @@ module Slack
           # @see https://api.slack.com/methods/files.comments.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files.comments/files.comments.delete.json
           def files_comments_delete(options = {})
-            throw ArgumentError.new('Required arguments :file missing') if options[:file].nil?
-            throw ArgumentError.new('Required arguments :id missing') if options[:id].nil?
+            raise ArgumentError, 'Required arguments :file missing' if options[:file].nil?
+            raise ArgumentError, 'Required arguments :id missing' if options[:id].nil?
             post('files.comments.delete', options)
           end
         end

--- a/lib/slack/web/api/endpoints/files_remote.rb
+++ b/lib/slack/web/api/endpoints/files_remote.rb
@@ -24,9 +24,9 @@ module Slack
           # @see https://api.slack.com/methods/files.remote.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files.remote/files.remote.add.json
           def files_remote_add(options = {})
-            throw ArgumentError.new('Required arguments :external_id missing') if options[:external_id].nil?
-            throw ArgumentError.new('Required arguments :external_url missing') if options[:external_url].nil?
-            throw ArgumentError.new('Required arguments :title missing') if options[:title].nil?
+            raise ArgumentError, 'Required arguments :external_id missing' if options[:external_id].nil?
+            raise ArgumentError, 'Required arguments :external_url missing' if options[:external_url].nil?
+            raise ArgumentError, 'Required arguments :title missing' if options[:title].nil?
             post('files.remote.add', options)
           end
 
@@ -94,7 +94,7 @@ module Slack
           # @see https://api.slack.com/methods/files.remote.share
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files.remote/files.remote.share.json
           def files_remote_share(options = {})
-            throw ArgumentError.new('Required arguments :channels missing') if options[:channels].nil?
+            raise ArgumentError, 'Required arguments :channels missing' if options[:channels].nil?
             post('files.remote.share', options)
           end
 

--- a/lib/slack/web/api/endpoints/migration.rb
+++ b/lib/slack/web/api/endpoints/migration.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/migration.exchange
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/migration/migration.exchange.json
           def migration_exchange(options = {})
-            throw ArgumentError.new('Required arguments :users missing') if options[:users].nil?
+            raise ArgumentError, 'Required arguments :users missing' if options[:users].nil?
             post('migration.exchange', options)
           end
         end

--- a/lib/slack/web/api/endpoints/oauth_v2.rb
+++ b/lib/slack/web/api/endpoints/oauth_v2.rb
@@ -37,8 +37,8 @@ module Slack
           # @see https://api.slack.com/methods/oauth.v2.exchange
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/oauth.v2/oauth.v2.exchange.json
           def oauth_v2_exchange(options = {})
-            throw ArgumentError.new('Required arguments :client_id missing') if options[:client_id].nil?
-            throw ArgumentError.new('Required arguments :client_secret missing') if options[:client_secret].nil?
+            raise ArgumentError, 'Required arguments :client_id missing' if options[:client_id].nil?
+            raise ArgumentError, 'Required arguments :client_secret missing' if options[:client_secret].nil?
             post('oauth.v2.exchange', options)
           end
         end

--- a/lib/slack/web/api/endpoints/pins.rb
+++ b/lib/slack/web/api/endpoints/pins.rb
@@ -16,7 +16,7 @@ module Slack
           # @see https://api.slack.com/methods/pins.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/pins/pins.add.json
           def pins_add(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('pins.add', options)
           end
@@ -29,7 +29,7 @@ module Slack
           # @see https://api.slack.com/methods/pins.list
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/pins/pins.list.json
           def pins_list(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('pins.list', options)
           end
@@ -44,7 +44,7 @@ module Slack
           # @see https://api.slack.com/methods/pins.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/pins/pins.remove.json
           def pins_remove(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('pins.remove', options)
           end

--- a/lib/slack/web/api/endpoints/presence.rb
+++ b/lib/slack/web/api/endpoints/presence.rb
@@ -13,7 +13,7 @@ module Slack
           # @see https://api.slack.com/methods/presence.set
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/presence.set.json
           def presence_set(options = {})
-            throw ArgumentError.new('Required arguments :presence missing') if options[:presence].nil?
+            raise ArgumentError, 'Required arguments :presence missing' if options[:presence].nil?
             post('presence.set', options)
           end
         end

--- a/lib/slack/web/api/endpoints/reactions.rb
+++ b/lib/slack/web/api/endpoints/reactions.rb
@@ -18,9 +18,9 @@ module Slack
           # @see https://api.slack.com/methods/reactions.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/reactions/reactions.add.json
           def reactions_add(options = {})
-            throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
-            throw ArgumentError.new('Required arguments :timestamp missing') if options[:timestamp].nil?
+            raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
+            raise ArgumentError, 'Required arguments :timestamp missing' if options[:timestamp].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('reactions.add', options)
           end
@@ -87,7 +87,7 @@ module Slack
           # @see https://api.slack.com/methods/reactions.remove
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/reactions/reactions.remove.json
           def reactions_remove(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
             post('reactions.remove', options)
           end

--- a/lib/slack/web/api/endpoints/reminders.rb
+++ b/lib/slack/web/api/endpoints/reminders.rb
@@ -22,8 +22,8 @@ module Slack
           # @see https://api.slack.com/methods/reminders.add
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/reminders/reminders.add.json
           def reminders_add(options = {})
-            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
-            throw ArgumentError.new('Required arguments :time missing') if options[:time].nil?
+            raise ArgumentError, 'Required arguments :text missing' if options[:text].nil?
+            raise ArgumentError, 'Required arguments :time missing' if options[:time].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             post('reminders.add', options)
           end
@@ -38,7 +38,7 @@ module Slack
           # @see https://api.slack.com/methods/reminders.complete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/reminders/reminders.complete.json
           def reminders_complete(options = {})
-            throw ArgumentError.new('Required arguments :reminder missing') if options[:reminder].nil?
+            raise ArgumentError, 'Required arguments :reminder missing' if options[:reminder].nil?
             post('reminders.complete', options)
           end
 
@@ -52,7 +52,7 @@ module Slack
           # @see https://api.slack.com/methods/reminders.delete
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/reminders/reminders.delete.json
           def reminders_delete(options = {})
-            throw ArgumentError.new('Required arguments :reminder missing') if options[:reminder].nil?
+            raise ArgumentError, 'Required arguments :reminder missing' if options[:reminder].nil?
             post('reminders.delete', options)
           end
 
@@ -66,7 +66,7 @@ module Slack
           # @see https://api.slack.com/methods/reminders.info
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/reminders/reminders.info.json
           def reminders_info(options = {})
-            throw ArgumentError.new('Required arguments :reminder missing') if options[:reminder].nil?
+            raise ArgumentError, 'Required arguments :reminder missing' if options[:reminder].nil?
             post('reminders.info', options)
           end
 

--- a/lib/slack/web/api/endpoints/search.rb
+++ b/lib/slack/web/api/endpoints/search.rb
@@ -22,7 +22,7 @@ module Slack
           # @see https://api.slack.com/methods/search.all
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/search/search.all.json
           def search_all(options = {})
-            throw ArgumentError.new('Required arguments :query missing') if options[:query].nil?
+            raise ArgumentError, 'Required arguments :query missing' if options[:query].nil?
             post('search.all', options)
           end
 
@@ -42,7 +42,7 @@ module Slack
           # @see https://api.slack.com/methods/search.files
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/search/search.files.json
           def search_files(options = {})
-            throw ArgumentError.new('Required arguments :query missing') if options[:query].nil?
+            raise ArgumentError, 'Required arguments :query missing' if options[:query].nil?
             post('search.files', options)
           end
 
@@ -64,7 +64,7 @@ module Slack
           # @see https://api.slack.com/methods/search.messages
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/search/search.messages.json
           def search_messages(options = {})
-            throw ArgumentError.new('Required arguments :query missing') if options[:query].nil?
+            raise ArgumentError, 'Required arguments :query missing' if options[:query].nil?
             if block_given?
               Pagination::Cursor.new(self, :search_messages, options).each do |page|
                 yield page

--- a/lib/slack/web/api/endpoints/tooling_tokens.rb
+++ b/lib/slack/web/api/endpoints/tooling_tokens.rb
@@ -14,7 +14,7 @@ module Slack
           # @see https://api.slack.com/methods/tooling.tokens.rotate
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/tooling.tokens/tooling.tokens.rotate.json
           def tooling_tokens_rotate(options = {})
-            throw ArgumentError.new('Required arguments :refresh_token missing') if options[:refresh_token].nil?
+            raise ArgumentError, 'Required arguments :refresh_token missing' if options[:refresh_token].nil?
             post('tooling.tokens.rotate', options)
           end
         end

--- a/lib/slack/web/api/endpoints/usergroups.rb
+++ b/lib/slack/web/api/endpoints/usergroups.rb
@@ -24,7 +24,7 @@ module Slack
           # @see https://api.slack.com/methods/usergroups.create
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/usergroups/usergroups.create.json
           def usergroups_create(options = {})
-            throw ArgumentError.new('Required arguments :name missing') if options[:name].nil?
+            raise ArgumentError, 'Required arguments :name missing' if options[:name].nil?
             post('usergroups.create', options)
           end
 
@@ -40,7 +40,7 @@ module Slack
           # @see https://api.slack.com/methods/usergroups.disable
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/usergroups/usergroups.disable.json
           def usergroups_disable(options = {})
-            throw ArgumentError.new('Required arguments :usergroup missing') if options[:usergroup].nil?
+            raise ArgumentError, 'Required arguments :usergroup missing' if options[:usergroup].nil?
             post('usergroups.disable', options)
           end
 
@@ -56,7 +56,7 @@ module Slack
           # @see https://api.slack.com/methods/usergroups.enable
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/usergroups/usergroups.enable.json
           def usergroups_enable(options = {})
-            throw ArgumentError.new('Required arguments :usergroup missing') if options[:usergroup].nil?
+            raise ArgumentError, 'Required arguments :usergroup missing' if options[:usergroup].nil?
             post('usergroups.enable', options)
           end
 
@@ -97,7 +97,7 @@ module Slack
           # @see https://api.slack.com/methods/usergroups.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/usergroups/usergroups.update.json
           def usergroups_update(options = {})
-            throw ArgumentError.new('Required arguments :usergroup missing') if options[:usergroup].nil?
+            raise ArgumentError, 'Required arguments :usergroup missing' if options[:usergroup].nil?
             post('usergroups.update', options)
           end
         end

--- a/lib/slack/web/api/endpoints/usergroups_users.rb
+++ b/lib/slack/web/api/endpoints/usergroups_users.rb
@@ -18,7 +18,7 @@ module Slack
           # @see https://api.slack.com/methods/usergroups.users.list
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/usergroups.users/usergroups.users.list.json
           def usergroups_users_list(options = {})
-            throw ArgumentError.new('Required arguments :usergroup missing') if options[:usergroup].nil?
+            raise ArgumentError, 'Required arguments :usergroup missing' if options[:usergroup].nil?
             post('usergroups.users.list', options)
           end
 
@@ -36,8 +36,8 @@ module Slack
           # @see https://api.slack.com/methods/usergroups.users.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/usergroups.users/usergroups.users.update.json
           def usergroups_users_update(options = {})
-            throw ArgumentError.new('Required arguments :usergroup missing') if options[:usergroup].nil?
-            throw ArgumentError.new('Required arguments :users missing') if options[:users].nil?
+            raise ArgumentError, 'Required arguments :usergroup missing' if options[:usergroup].nil?
+            raise ArgumentError, 'Required arguments :users missing' if options[:users].nil?
             post('usergroups.users.update', options)
           end
         end

--- a/lib/slack/web/api/endpoints/users.rb
+++ b/lib/slack/web/api/endpoints/users.rb
@@ -74,7 +74,7 @@ module Slack
           # @see https://api.slack.com/methods/users.info
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/users/users.info.json
           def users_info(options = {})
-            throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+            raise ArgumentError, 'Required arguments :user missing' if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             post('users.info', options)
           end
@@ -110,7 +110,7 @@ module Slack
           # @see https://api.slack.com/methods/users.lookupByEmail
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/users/users.lookupByEmail.json
           def users_lookupByEmail(options = {})
-            throw ArgumentError.new('Required arguments :email missing') if options[:email].nil?
+            raise ArgumentError, 'Required arguments :email missing' if options[:email].nil?
             post('users.lookupByEmail', options)
           end
 
@@ -148,7 +148,7 @@ module Slack
           # @see https://api.slack.com/methods/users.setPresence
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/users/users.setPresence.json
           def users_setPresence(options = {})
-            throw ArgumentError.new('Required arguments :presence missing') if options[:presence].nil?
+            raise ArgumentError, 'Required arguments :presence missing' if options[:presence].nil?
             post('users.setPresence', options)
           end
         end

--- a/lib/slack/web/api/endpoints/users_admin.rb
+++ b/lib/slack/web/api/endpoints/users_admin.rb
@@ -25,7 +25,7 @@ module Slack
           #   Invite a guest that can use one channel only
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/users.admin/users.admin.invite.json
           def users_admin_invite(options = {})
-            throw ArgumentError.new('Required arguments :email missing') if options[:email].nil?
+            raise ArgumentError, 'Required arguments :email missing' if options[:email].nil?
             logger.warn('The users.admin.invite method is undocumented.')
             post('users.admin.invite', options)
           end
@@ -37,7 +37,7 @@ module Slack
           #   User to disable
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/undocumented/users.admin/users.admin.setInactive.json
           def users_admin_setInactive(options = {})
-            throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+            raise ArgumentError, 'Required arguments :user missing' if options[:user].nil?
             options = options.merge(user: users_id(options)['user']['id']) if options[:user]
             logger.warn('The users.admin.setInactive method is undocumented.')
             post('users.admin.setInactive', options)

--- a/lib/slack/web/api/endpoints/views.rb
+++ b/lib/slack/web/api/endpoints/views.rb
@@ -16,8 +16,8 @@ module Slack
           # @see https://api.slack.com/methods/views.open
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/views/views.open.json
           def views_open(options = {})
-            throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
-            throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+            raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
+            raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
             if options.key?(:view)
               view = options[:view]
               view = JSON.dump(view) unless view.is_a?(String)
@@ -38,8 +38,8 @@ module Slack
           # @see https://api.slack.com/methods/views.publish
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/views/views.publish.json
           def views_publish(options = {})
-            throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
-            throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+            raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
+            raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
             if options.key?(:view)
               view = options[:view]
               view = JSON.dump(view) unless view.is_a?(String)
@@ -58,8 +58,8 @@ module Slack
           # @see https://api.slack.com/methods/views.push
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/views/views.push.json
           def views_push(options = {})
-            throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
-            throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+            raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
+            raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
             if options.key?(:view)
               view = options[:view]
               view = JSON.dump(view) unless view.is_a?(String)
@@ -82,7 +82,7 @@ module Slack
           # @see https://api.slack.com/methods/views.update
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/views/views.update.json
           def views_update(options = {})
-            throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+            raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
             if options.key?(:view)
               view = options[:view]
               view = JSON.dump(view) unless view.is_a?(String)

--- a/lib/slack/web/api/endpoints/workflows.rb
+++ b/lib/slack/web/api/endpoints/workflows.rb
@@ -16,7 +16,7 @@ module Slack
           # @see https://api.slack.com/methods/workflows.stepCompleted
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/workflows/workflows.stepCompleted.json
           def workflows_stepCompleted(options = {})
-            throw ArgumentError.new('Required arguments :workflow_step_execute_id missing') if options[:workflow_step_execute_id].nil?
+            raise ArgumentError, 'Required arguments :workflow_step_execute_id missing' if options[:workflow_step_execute_id].nil?
             post('workflows.stepCompleted', options)
           end
 
@@ -30,8 +30,8 @@ module Slack
           # @see https://api.slack.com/methods/workflows.stepFailed
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/workflows/workflows.stepFailed.json
           def workflows_stepFailed(options = {})
-            throw ArgumentError.new('Required arguments :error missing') if options[:error].nil?
-            throw ArgumentError.new('Required arguments :workflow_step_execute_id missing') if options[:workflow_step_execute_id].nil?
+            raise ArgumentError, 'Required arguments :error missing' if options[:error].nil?
+            raise ArgumentError, 'Required arguments :workflow_step_execute_id missing' if options[:workflow_step_execute_id].nil?
             post('workflows.stepFailed', options)
           end
 
@@ -51,7 +51,7 @@ module Slack
           # @see https://api.slack.com/methods/workflows.updateStep
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/workflows/workflows.updateStep.json
           def workflows_updateStep(options = {})
-            throw ArgumentError.new('Required arguments :workflow_step_edit_id missing') if options[:workflow_step_edit_id].nil?
+            raise ArgumentError, 'Required arguments :workflow_step_edit_id missing' if options[:workflow_step_edit_id].nil?
             post('workflows.updateStep', options)
           end
         end

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -14,7 +14,7 @@ module Slack
           #   Channel to get ID for, prefixed with #.
           def conversations_id(options = {})
             name = options[:channel]
-            throw ArgumentError.new('Required arguments :channel missing') if name.nil?
+            raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 
             id_for :channel, name, '#', :conversations_list, :channels, 'channel_not_found'
           end

--- a/lib/slack/web/api/mixins/users.id.rb
+++ b/lib/slack/web/api/mixins/users.id.rb
@@ -14,7 +14,7 @@ module Slack
           #   User to get ID for, prefixed with '@'.
           def users_id(options = {})
             name = options[:user]
-            throw ArgumentError.new('Required arguments :user missing') if name.nil?
+            raise ArgumentError, 'Required arguments :user missing' if name.nil?
 
             id_for :user, name, '@', :users_list, :members, 'user_not_found'
           end

--- a/lib/slack/web/api/mixins/users.search.rb
+++ b/lib/slack/web/api/mixins/users.search.rb
@@ -14,7 +14,8 @@ if defined?(Picky)
             #   Free-formed text to search for.
             def users_search(options = {})
               query = options[:user]
-              throw ArgumentError.new('Required arguments :user missing') if query.nil?
+              raise ArgumentError, 'Required arguments :user missing' if query.nil?
+
               index = Picky::Index.new(:users) do
                 category :name
                 category :first_name

--- a/lib/slack/web/api/patches/chat.1.patch
+++ b/lib/slack/web/api/patches/chat.1.patch
@@ -6,10 +6,10 @@ index d090ae2..50186d5 100644
            # @see https://api.slack.com/methods/chat.postEphemeral
            # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postEphemeral.json
            def chat_postEphemeral(options = {})
-             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
--            throw ArgumentError.new('Required arguments :text missing') if options[:text].nil?
-+            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
-             throw ArgumentError.new('Required arguments :user missing') if options[:user].nil?
+             raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
+-            raise ArgumentError, 'Required arguments :text missing' if options[:text].nil?
++            raise ArgumentError, 'Required arguments :text, :attachments or :blocks missing' if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+             raise ArgumentError, 'Required arguments :user missing' if options[:user].nil?
              options = options.merge(user: users_id(options)['user']['id']) if options[:user]
 +            # attachments must be passed as an encoded JSON string
 +            if options.key?(:attachments)
@@ -29,8 +29,8 @@ index d090ae2..50186d5 100644
 @@ -168,6 +179,19 @@ module Slack
            # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.postMessage.json
            def chat_postMessage(options = {})
-             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-+            throw ArgumentError.new('Required arguments :text, :attachments or :blocks missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
+             raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
++            raise ArgumentError, 'Required arguments :text, :attachments or :blocks missing' if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil?
 +            # attachments must be passed as an encoded JSON string
 +            if options.key?(:attachments)
 +              attachments = options[:attachments]
@@ -49,9 +49,9 @@ index d090ae2..50186d5 100644
 @@ -257,8 +281,21 @@ module Slack
            # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/chat/chat.update.json
            def chat_update(options = {})
-             throw ArgumentError.new('Required arguments :channel missing') if options[:channel].nil?
-+            throw ArgumentError.new('Required arguments :text, :attachments, :blocks or :reply_broadcast missing') if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil? && options[:reply_broadcast].nil?
-             throw ArgumentError.new('Required arguments :ts missing') if options[:ts].nil?
+             raise ArgumentError, 'Required arguments :channel missing' if options[:channel].nil?
++            raise ArgumentError, 'Required arguments :text, :attachments, :blocks or :reply_broadcast missing' if options[:text].nil? && options[:attachments].nil? && options[:blocks].nil? && options[:reply_broadcast].nil?
+             raise ArgumentError, 'Required arguments :ts missing' if options[:ts].nil?
              options = options.merge(channel: conversations_id(options)['channel']['id']) if options[:channel]
 +            # attachments must be passed as an encoded JSON string
 +            if options.key?(:attachments)

--- a/lib/slack/web/api/patches/dialog.1.open-json-support.patch
+++ b/lib/slack/web/api/patches/dialog.1.open-json-support.patch
@@ -4,8 +4,8 @@ index 01f9dfd..d017adf 100644
 +++ b/lib/slack/web/api/endpoints/dialog.rb
 @@ -17,6 +17,12 @@ module Slack
            def dialog_open(options = {})
-             throw ArgumentError.new('Required arguments :dialog missing') if options[:dialog].nil?
-             throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
+             raise ArgumentError, 'Required arguments :dialog missing' if options[:dialog].nil?
+             raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
 +            # dialog must be passed as an encoded JSON string
 +            if options.key?(:dialog)
 +              dialog = options[:dialog]

--- a/lib/slack/web/api/patches/views.1.view-json.patch
+++ b/lib/slack/web/api/patches/views.1.view-json.patch
@@ -4,8 +4,8 @@ index 3d7ac8e..10de15c 100644
 +++ b/lib/slack/web/api/endpoints/views.rb
 @@ -18,6 +18,11 @@ module Slack
            def views_open(options = {})
-             throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
-             throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+             raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
+             raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
 +            if options.key?(:view)
 +              view = options[:view]
 +              view = JSON.dump(view) unless view.is_a?(String)
@@ -16,8 +16,8 @@ index 3d7ac8e..10de15c 100644
  
 @@ -33,6 +38,11 @@ module Slack
            def views_push(options = {})
-             throw ArgumentError.new('Required arguments :trigger_id missing') if options[:trigger_id].nil?
-             throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+             raise ArgumentError, 'Required arguments :trigger_id missing' if options[:trigger_id].nil?
+             raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
 +            if options.key?(:view)
 +              view = options[:view]
 +              view = JSON.dump(view) unless view.is_a?(String)
@@ -29,7 +29,7 @@ index 3d7ac8e..10de15c 100644
 @@ -51,6 +61,11 @@ module Slack
            # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/views/views.update.json
            def views_update(options = {})
-             throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+             raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
 +            if options.key?(:view)
 +              view = options[:view]
 +              view = JSON.dump(view) unless view.is_a?(String)

--- a/lib/slack/web/api/patches/views.1.views-published.patch
+++ b/lib/slack/web/api/patches/views.1.views-published.patch
@@ -4,8 +4,8 @@ index 31626b9..8182a9c 100644
 +++ b/lib/slack/web/api/endpoints/views.rb
 @@ -40,6 +40,11 @@ module Slack
            def views_publish(options = {})
-             throw ArgumentError.new('Required arguments :user_id missing') if options[:user_id].nil?
-             throw ArgumentError.new('Required arguments :view missing') if options[:view].nil?
+             raise ArgumentError, 'Required arguments :user_id missing' if options[:user_id].nil?
+             raise ArgumentError, 'Required arguments :view missing' if options[:view].nil?
 +            if options.key?(:view)
 +              view = options[:view]
 +              view = JSON.dump(view) unless view.is_a?(String)

--- a/lib/slack/web/api/templates/method.erb
+++ b/lib/slack/web/api/templates/method.erb
@@ -35,7 +35,7 @@ module Slack
 <% end %>
           def <%= group.gsub(".", "_") %>_<%= name %>(options = {})
 <% data['args'].select{ |k, v| v['required'] }.each do |arg_name, arg_v| %>
-            throw ArgumentError.new('Required arguments :<%= arg_name %> missing') if options[:<%= arg_name %>].nil?
+            raise ArgumentError, 'Required arguments :<%= arg_name %> missing' if options[:<%= arg_name %>].nil?
 <% end %>
 <% if data['group'] == 'groups' && data['args']['channel'] && !data['args']['channel']['desc'].include?('Can be an encoded ID, or a name.') %>
             options = options.merge(channel: groups_id(options)['group']['id']) if options[:channel]

--- a/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
+++ b/spec/slack/web/api/endpoints/custom_specs/chat_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Slack::Web::Api::Endpoints::Chat do
       it 'requires ts' do
         expect do
           client.chat_update(channel: 'channel', text: 'text')
-        end.to raise_error(ArgumentError, /Required arguments :ts missing>/)
+        end.to raise_error(ArgumentError, /Required arguments :ts missing/)
       end
     end
 


### PR DESCRIPTION
This commit replaces all instances of `throw` with `raise`.

While I was using this library, I noticed that error handling didn't
work as expected.

Here's an example of what I tried. Looking at the code, I expected this
to print `ArgumentError`, but it printed `UncaughtThrowError`.

```ruby
client = Slack::Web::Client.new(token: ENV["TOKEN"])
begin
  client.chat_postMessage
rescue => e
  puts e.class
end
# UncaughtThrowError
```

According to Ruby's [tutorial on Exceptions][1], `raise` and `rescue`
should be used for exceptions, while `throw` and `catch` could be used
for control flow.

[1]: https://ruby-doc.com/docs/ProgrammingRuby/html/tut_exceptions.html