### PR TITLE
Fix default store missing event hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#416](https://github.com/slack-ruby/slack-ruby-client/pull/416): Removes default values for Faraday's SSL settings `ca_file` and `ca_path` - [@irphilli](https://github.com/irphilli).
 * [#417](https://github.com/slack-ruby/slack-ruby-client/pull/417): Raise rescuable errors - [@zachahn](https://github.com/zachahn).
 * [#419](https://github.com/slack-ruby/slack-ruby-client/pull/419): Use `rtm.connect` instead of `rtm.start` - [@kstole](https://github.com/kstole).
+* [#420](https://github.com/slack-ruby/slack-ruby-client/pull/420): Fix default store missing event hooks - [@kstole](https://github.com/kstole).
 * Your contribution here.
 
 ### 1.1.0 (2022/06/05)

--- a/lib/slack/real_time/client.rb
+++ b/lib/slack/real_time/client.rb
@@ -11,12 +11,6 @@ module Slack
       include Api::Message
       include Api::Typing
 
-      @events = {}
-
-      class << self
-        attr_accessor :events
-      end
-
       attr_accessor :web_client, :store, :url, *Config::ATTRIBUTES
 
       protected :store_class, :store_class=
@@ -239,10 +233,8 @@ module Slack
       end
 
       def run_handlers(type, data)
-        return unless store.class.events
-
         handlers = store.class.events[type.to_s]
-        handlers&.each do |handler|
+        handlers.each do |handler|
           store.instance_exec(data, &handler)
         end
       rescue StandardError => e

--- a/lib/slack/real_time/stores/base.rb
+++ b/lib/slack/real_time/stores/base.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
+
 module Slack
   module RealTime
     module Stores
       # Doesn't store anything.
       class Base
+        @events = Hash.new { |h, k| h[k] = [] }
+
         class << self
-          attr_accessor :events
+          attr_reader :events
+
+          def inherited(subclass)
+            super
+            subclass.instance_variable_set :@events, events.dup
+          end
+
+          def on(event, &handler)
+            events[event.to_s] << handler
+          end
         end
 
         attr_accessor :users, :bots, :channels, :groups, :teams, :ims
@@ -19,12 +31,6 @@ module Slack
         end
 
         def initialize(_attrs); end
-
-        def self.on(event, &block)
-          self.events ||= {}
-          self.events[event.to_s] ||= []
-          self.events[event.to_s] << block
-        end
       end
     end
   end

--- a/spec/slack/real_time/client_spec.rb
+++ b/spec/slack/real_time/client_spec.rb
@@ -159,18 +159,18 @@ RSpec.describe Slack::RealTime::Client do
       end
 
       describe '#run_handlers' do
-        describe 'empty events' do
+        context 'when store has no event hooks' do
           before do
-            @e = client.store.class.events
-            client.store.class.events = nil
+            @events = client.store.class.events.dup
+            client.store.class.events.clear
           end
 
           after do
-            client.store.class.events = @e
+            client.store.class.events.merge!(@events)
           end
 
-          it 'returns false when event is nil' do
-            expect(client.send(:run_handlers, 'example', {})).to be_nil
+          it 'returns empty array of handlers' do
+            expect(client.send(:run_handlers, 'example', {})).to be_empty
           end
         end
       end

--- a/spec/slack/real_time/store_spec.rb
+++ b/spec/slack/real_time/store_spec.rb
@@ -9,4 +9,9 @@ RSpec.describe Slack::RealTime::Store do
     expect(store.team).to be_nil
     expect(store.teams.count).to eq 0
   end
+
+  it 'includes event handlers from superclass' do
+    Slack::RealTime::Stores::Store.on :channel_created, &proc {}
+    expect(described_class.events.key?('channel_created')).to be true
+  end
 end


### PR DESCRIPTION
The default Slack store (`Slack::RealTime::Store`) inherits from `Slack::RealTime::Stores::Store` but didn't have access to its event hooks stored in a class instance variable of the superclass. This ensures store subclasses inherit the event hooks from their inheritance chain.