### PR TITLE
Update real_time.rake to remove outdated event hooks and organize alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#420](https://github.com/slack-ruby/slack-ruby-client/pull/420): Fix default store missing event hooks - [@kstole](https://github.com/kstole).
 * [#421](https://github.com/slack-ruby/slack-ruby-client/pull/421): Added `admin_audit_anomaly_allow_getItem`, `admin_audit_anomaly_allow_updateItem`, `files_completeUploadExternal`, `files_getUploadURLExternal` - [@kstole](https://github.com/kstole).
 * [#421](https://github.com/slack-ruby/slack-ruby-client/pull/421): Raise error for mutually exclusive required options in views methods - [@kstole](https://github.com/kstole).
+* [#424](https://github.com/slack-ruby/slack-ruby-client/pull/424): Updated real_time.rake to remove outdated event hooks and organize alphabetically - [@kstole](https://github.com/kstole).
 * Your contribution here.
 
 ### 1.1.0 (2022/06/05)

--- a/bin/commands/files.rb
+++ b/bin/commands/files.rb
@@ -35,8 +35,8 @@ command 'files' do |g|
     end
   end
 
-  g.desc 'Gets a URL for an edge external upload'
-  g.long_desc %( Gets a URL for an edge external upload )
+  g.desc 'Gets a URL for an edge external file upload'
+  g.long_desc %( Gets a URL for an edge external file upload )
   g.command 'getUploadURLExternal' do |c|
     c.flag 'filename', desc: 'Name of the file being uploaded.'
     c.flag 'length', desc: 'Size in bytes of the file being uploaded.'

--- a/lib/slack/real_time/api/templates/event_handler.erb
+++ b/lib/slack/real_time/api/templates/event_handler.erb
@@ -1,4 +1,8 @@
         # <%= desc %>
         # @see https://api.slack.com/events/<%= name %>
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/<%= name %>.json
-        # on :<%= name %> do |data|
+<% if hook %>
+<%= hook %>
+<% else %>
+          # on :<%= name %> do |data|
+<% end %>

--- a/lib/slack/real_time/stores/starter.rb
+++ b/lib/slack/real_time/stores/starter.rb
@@ -13,75 +13,412 @@ module Slack
 
         ### RealTime Events
 
-        # A user's status has changed.
-        # @see https://api.slack.com/events/user_status_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_status_changed.json
-        # on :user_status_changed do |data|
+        # The list of accounts a user is signed into has changed.
+        # @see https://api.slack.com/events/accounts_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/accounts_changed.json
+        # on :accounts_changed do |data|
 
-        # A user's profile data has changed.
-        # @see https://api.slack.com/events/user_profile_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_profile_changed.json
-        # on :user_profile_changed do |data|
+        # A bot user was added.
+        # @see https://api.slack.com/events/bot_added
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/bot_added.json
+        # on :bot_added do |data|
 
-        # A user's huddle status has changed.
-        # @see https://api.slack.com/events/user_huddle_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_huddle_changed.json
-        # on :user_huddle_changed do |data|
+        # A bot user was changed.
+        # @see https://api.slack.com/events/bot_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/bot_changed.json
+        # on :bot_changed do |data|
 
-        # A shared channel invite was sent to a Slack user.
-        # @see https://api.slack.com/events/shared_channel_invite_received
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/shared_channel_invite_received.json
-        # on :shared_channel_invite_received do |data|
+        # A channel was archived.
+        # @see https://api.slack.com/events/channel_archive
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_archive.json
+        # on :channel_archive do |data|
 
-        # An enterprise grid migration has started on an external workspace..
-        # @see https://api.slack.com/events/external_org_migration_started
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_started.json
-        # on :external_org_migration_started do |data|
+        # A channel was created.
+        # @see https://api.slack.com/events/channel_created
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_created.json
+        # on :channel_created do |data|
+
+        # A channel was deleted.
+        # @see https://api.slack.com/events/channel_deleted
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_deleted.json
+        # on :channel_deleted do |data|
+
+        # Bulk updates were made to a channel's history.
+        # @see https://api.slack.com/events/channel_history_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_history_changed.json
+        # on :channel_history_changed do |data|
+
+        # You joined a channel.
+        # @see https://api.slack.com/events/channel_joined
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_joined.json
+        # on :channel_joined do |data|
+
+        # You left a channel.
+        # @see https://api.slack.com/events/channel_left
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_left.json
+        # on :channel_left do |data|
+
+        # Your channel read marker was updated.
+        # @see https://api.slack.com/events/channel_marked
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_marked.json
+        # on :channel_marked do |data|
+
+        # A channel was renamed.
+        # @see https://api.slack.com/events/channel_rename
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_rename.json
+        # on :channel_rename do |data|
+
+        # A channel was unarchived.
+        # @see https://api.slack.com/events/channel_unarchive
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_unarchive.json
+        # on :channel_unarchive do |data|
+
+        # A slash command has been added or changed.
+        # @see https://api.slack.com/events/commands_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/commands_changed.json
+        # on :commands_changed do |data|
+
+        # Do not Disturb settings changed for the current user.
+        # @see https://api.slack.com/events/dnd_updated
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/dnd_updated.json
+        # on :dnd_updated do |data|
+
+        # Do not Disturb settings changed for a member.
+        # @see https://api.slack.com/events/dnd_updated_user
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/dnd_updated_user.json
+        # on :dnd_updated_user do |data|
+
+        # The workspace email domain has changed.
+        # @see https://api.slack.com/events/email_domain_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/email_domain_changed.json
+        on :email_domain_changed do |data|
+          team.email_domain = data.email_domain
+        end
+
+        # A custom emoji has been added or changed.
+        # @see https://api.slack.com/events/emoji_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/emoji_changed.json
+        # on :emoji_changed do |data|
 
         # An enterprise grid migration has finished on an external workspace..
         # @see https://api.slack.com/events/external_org_migration_finished
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_finished.json
         # on :external_org_migration_finished do |data|
 
-        # A private channel was deleted.
-        # @see https://api.slack.com/events/group_deleted
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_deleted.json
-        # on :group_deleted do |data|
+        # An enterprise grid migration has started on an external workspace..
+        # @see https://api.slack.com/events/external_org_migration_started
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_started.json
+        # on :external_org_migration_started do |data|
 
-        # Determine the current presence status for a list of users.
-        # @see https://api.slack.com/events/presence_query
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_query.json
-        # on :presence_query do |data|
+        # A file was changed.
+        # @see https://api.slack.com/events/file_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_change.json
+        # on :file_change do |data|
 
-        # The membership of an existing User Group has changed.
-        # @see https://api.slack.com/events/subteam_members_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_members_changed.json
-        # on :subteam_members_changed do |data|
+        # A file comment was added.
+        # @see https://api.slack.com/events/file_comment_added
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_added.json
+        # on :file_comment_added do |data|
 
-        # Subscribe to presence events for the specified users.
-        # @see https://api.slack.com/events/presence_sub
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_sub.json
-        # on :presence_sub do |data|
+        # A file comment was deleted.
+        # @see https://api.slack.com/events/file_comment_deleted
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_deleted.json
+        # on :file_comment_deleted do |data|
 
-        # A user left a public or private channel.
-        # @see https://api.slack.com/events/member_left_channel
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_left_channel.json
-        # on :member_left_channel do |data|
+        # A file comment was edited.
+        # @see https://api.slack.com/events/file_comment_edited
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_edited.json
+        # on :file_comment_edited do |data|
 
-        # A user joined a public or private channel.
-        # @see https://api.slack.com/events/member_joined_channel
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_joined_channel.json
-        # on :member_joined_channel do |data|
+        # A file was created.
+        # @see https://api.slack.com/events/file_created
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_created.json
+        # on :file_created do |data|
+
+        # A file was deleted.
+        # @see https://api.slack.com/events/file_deleted
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_deleted.json
+        # on :file_deleted do |data|
+
+        # A file was made public.
+        # @see https://api.slack.com/events/file_public
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_public.json
+        # on :file_public do |data|
+
+        # A file was shared.
+        # @see https://api.slack.com/events/file_shared
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_shared.json
+        # on :file_shared do |data|
+
+        # A file was unshared.
+        # @see https://api.slack.com/events/file_unshared
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_unshared.json
+        # on :file_unshared do |data|
 
         # The server intends to close the connection soon..
         # @see https://api.slack.com/events/goodbye
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/goodbye.json
         # on :goodbye do |data|
 
-        # Verifies ownership of an Events API Request URL.
-        # @see https://api.slack.com/events/url_verification
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/url_verification.json
-        # on :url_verification do |data|
+        # A private channel was archived.
+        # @see https://api.slack.com/events/group_archive
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_archive.json
+        # on :group_archive do |data|
+
+        # You closed a private channel.
+        # @see https://api.slack.com/events/group_close
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_close.json
+        # on :group_close do |data|
+
+        # A private channel was deleted.
+        # @see https://api.slack.com/events/group_deleted
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_deleted.json
+        # on :group_deleted do |data|
+
+        # Bulk updates were made to a private channel's history.
+        # @see https://api.slack.com/events/group_history_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_history_changed.json
+        # on :group_history_changed do |data|
+
+        # You joined a private channel.
+        # @see https://api.slack.com/events/group_joined
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_joined.json
+        # on :group_joined do |data|
+
+        # You left a private channel.
+        # @see https://api.slack.com/events/group_left
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_left.json
+        # on :group_left do |data|
+
+        # A private channel read marker was updated.
+        # @see https://api.slack.com/events/group_marked
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_marked.json
+        # on :group_marked do |data|
+
+        # You created a group DM.
+        # @see https://api.slack.com/events/group_open
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_open.json
+        # on :group_open do |data|
+
+        # A private channel was renamed.
+        # @see https://api.slack.com/events/group_rename
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_rename.json
+        # on :group_rename do |data|
+
+        # A private channel was unarchived.
+        # @see https://api.slack.com/events/group_unarchive
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_unarchive.json
+        # on :group_unarchive do |data|
+
+        # The client has successfully connected to the server.
+        # @see https://api.slack.com/events/hello
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/hello.json
+        # on :hello do |data|
+
+        # You closed a DM.
+        # @see https://api.slack.com/events/im_close
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_close.json
+        # on :im_close do |data|
+
+        # A DM was created.
+        # @see https://api.slack.com/events/im_created
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_created.json
+        # on :im_created do |data|
+
+        # Bulk updates were made to a DM's history.
+        # @see https://api.slack.com/events/im_history_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_history_changed.json
+        # on :im_history_changed do |data|
+
+        # A direct message read marker was updated.
+        # @see https://api.slack.com/events/im_marked
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_marked.json
+        # on :im_marked do |data|
+
+        # You opened a DM.
+        # @see https://api.slack.com/events/im_open
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_open.json
+        # on :im_open do |data|
+
+        # You manually updated your presence.
+        # @see https://api.slack.com/events/manual_presence_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/manual_presence_change.json
+        # on :manual_presence_change do |data|
+
+        # A user joined a public channel, private channel or MPDM..
+        # @see https://api.slack.com/events/member_joined_channel
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_joined_channel.json
+        # on :member_joined_channel do |data|
+
+        # A user left a public or private channel.
+        # @see https://api.slack.com/events/member_left_channel
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_left_channel.json
+        # on :member_left_channel do |data|
+
+        # A pin was added to a channel.
+        # @see https://api.slack.com/events/pin_added
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/pin_added.json
+        # on :pin_added do |data|
+
+        # A pin was removed from a channel.
+        # @see https://api.slack.com/events/pin_removed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/pin_removed.json
+        # on :pin_removed do |data|
+
+        # You have updated your preferences.
+        # @see https://api.slack.com/events/pref_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/pref_change.json
+        # on :pref_change do |data|
+
+        # A member's presence changed.
+        # @see https://api.slack.com/events/presence_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_change.json
+        # on :presence_change do |data|
+
+        # Determine the current presence status for a list of users.
+        # @see https://api.slack.com/events/presence_query
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_query.json
+        # on :presence_query do |data|
+
+        # Subscribe to presence events for the specified users.
+        # @see https://api.slack.com/events/presence_sub
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_sub.json
+        # on :presence_sub do |data|
+
+        # A member has added an emoji reaction to an item.
+        # @see https://api.slack.com/events/reaction_added
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reaction_added.json
+        # on :reaction_added do |data|
+
+        # A member removed an emoji reaction.
+        # @see https://api.slack.com/events/reaction_removed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reaction_removed.json
+        # on :reaction_removed do |data|
+
+        # Experimental.
+        # @see https://api.slack.com/events/reconnect_url
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reconnect_url.json
+        # on :reconnect_url do |data|
+
+        # A shared channel invite was sent to a Slack user.
+        # @see https://api.slack.com/events/shared_channel_invite_received
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/shared_channel_invite_received.json
+        # on :shared_channel_invite_received do |data|
+
+        # A member has starred an item.
+        # @see https://api.slack.com/events/star_added
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/star_added.json
+        # on :star_added do |data|
+
+        # A member removed a star.
+        # @see https://api.slack.com/events/star_removed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/star_removed.json
+        # on :star_removed do |data|
+
+        # A User Group has been added to the workspace.
+        # @see https://api.slack.com/events/subteam_created
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_created.json
+        # on :subteam_created do |data|
+
+        # The membership of an existing User Group has changed.
+        # @see https://api.slack.com/events/subteam_members_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_members_changed.json
+        # on :subteam_members_changed do |data|
+
+        # You have been added to a User Group.
+        # @see https://api.slack.com/events/subteam_self_added
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_self_added.json
+        # on :subteam_self_added do |data|
+
+        # You have been removed from a User Group.
+        # @see https://api.slack.com/events/subteam_self_removed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_self_removed.json
+        # on :subteam_self_removed do |data|
+
+        # An existing User Group has been updated or its members changed.
+        # @see https://api.slack.com/events/subteam_updated
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_updated.json
+        # on :subteam_updated do |data|
+
+        # The workspace domain has changed.
+        # @see https://api.slack.com/events/team_domain_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_domain_change.json
+        on :team_domain_change do |data|
+          team.url = data.url
+          team.domain = data.domain
+        end
+
+        # A new member has joined.
+        # @see https://api.slack.com/events/team_join
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_join.json
+        # on :team_join do |data|
+
+        # The workspace is being migrated between servers.
+        # @see https://api.slack.com/events/team_migration_started
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_migration_started.json
+        # on :team_migration_started do |data|
+
+        # The account billing plan has changed.
+        # @see https://api.slack.com/events/team_plan_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_plan_change.json
+        on :team_plan_change do |data|
+          team.plan = data.plan
+        end
+
+        # A preference has been updated.
+        # @see https://api.slack.com/events/team_pref_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_pref_change.json
+        on :team_pref_change do |data|
+          team.prefs ||= {}
+          team.prefs[data.name] = data.value
+        end
+
+        # The workspace profile fields have been updated.
+        # @see https://api.slack.com/events/team_profile_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_change.json
+        # on :team_profile_change do |data|
+
+        # The workspace profile fields have been deleted.
+        # @see https://api.slack.com/events/team_profile_delete
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_delete.json
+        # on :team_profile_delete do |data|
+
+        # The workspace profile fields have been reordered.
+        # @see https://api.slack.com/events/team_profile_reorder
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_reorder.json
+        # on :team_profile_reorder do |data|
+
+        # The workspace name has changed.
+        # @see https://api.slack.com/events/team_rename
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_rename.json
+        on :team_rename do |data|
+          team.name = data.name
+        end
+
+        # A member's data has changed.
+        # @see https://api.slack.com/events/user_change
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_change.json
+        # on :user_change do |data|
+
+        # A user's huddle status has changed.
+        # @see https://api.slack.com/events/user_huddle_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_huddle_changed.json
+        # on :user_huddle_changed do |data|
+
+        # A user's profile data has changed.
+        # @see https://api.slack.com/events/user_profile_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_profile_changed.json
+        # on :user_profile_changed do |data|
+
+        # A user's status has changed.
+        # @see https://api.slack.com/events/user_status_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_status_changed.json
+        # on :user_status_changed do |data|
+
+        # A channel member is typing a message.
+        # @see https://api.slack.com/events/user_typing
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_typing.json
+        # on :user_typing do |data|
 
         # A message was posted in a multiparty direct message channel.
         # @see https://api.slack.com/events/message.mpim
@@ -102,348 +439,6 @@ module Slack
         # @see https://api.slack.com/events/message.channels
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/message.channels.json
         # on :message.channels do |data|
-
-        # A channel member is typing a message.
-        # @see https://api.slack.com/events/user_typing
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_typing.json
-        # on :user_typing do |data|
-
-        # A team member's data has changed.
-        # @see https://api.slack.com/events/user_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_change.json
-        # on :user_change do |data|
-
-        # A new team member has joined.
-        # @see https://api.slack.com/events/team_join
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_join.json
-        # on :team_join do |data|
-
-        # An existing user group has been updated or its members changed.
-        # @see https://api.slack.com/events/subteam_updated
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_updated.json
-        # on :subteam_updated do |data|
-
-        # You have been removed from a user group.
-        # @see https://api.slack.com/events/subteam_self_removed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_self_removed.json
-        # on :subteam_self_removed do |data|
-
-        # You have been added to a user group.
-        # @see https://api.slack.com/events/subteam_self_added
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_self_added.json
-        # on :subteam_self_added do |data|
-
-        # A user group has been added to the team.
-        # @see https://api.slack.com/events/subteam_created
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_created.json
-        # on :subteam_created do |data|
-
-        # A team member removed a star.
-        # @see https://api.slack.com/events/star_removed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/star_removed.json
-        # on :star_removed do |data|
-
-        # A team member has starred an item.
-        # @see https://api.slack.com/events/star_added
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/star_added.json
-        # on :star_added do |data|
-
-        # Experimental.
-        # @see https://api.slack.com/events/reconnect_url
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reconnect_url.json
-        # on :reconnect_url do |data|
-
-        # A team member removed an emoji reaction.
-        # @see https://api.slack.com/events/reaction_removed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reaction_removed.json
-        # on :reaction_removed do |data|
-
-        # A team member has added an emoji reaction to an item.
-        # @see https://api.slack.com/events/reaction_added
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reaction_added.json
-        # on :reaction_added do |data|
-
-        # A team member's presence changed.
-        # @see https://api.slack.com/events/presence_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_change.json
-        # on :presence_change do |data|
-
-        # You have updated your preferences.
-        # @see https://api.slack.com/events/pref_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/pref_change.json
-        # on :pref_change do |data|
-
-        # A pin was removed from a channel.
-        # @see https://api.slack.com/events/pin_removed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/pin_removed.json
-        # on :pin_removed do |data|
-
-        # A pin was added to a channel.
-        # @see https://api.slack.com/events/pin_added
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/pin_added.json
-        # on :pin_added do |data|
-
-        # You manually updated your presence.
-        # @see https://api.slack.com/events/manual_presence_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/manual_presence_change.json
-        # on :manual_presence_change do |data|
-
-        # You opened a direct message channel.
-        # @see https://api.slack.com/events/im_open
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_open.json
-        # on :im_open do |data|
-
-        # A direct message read marker was updated.
-        # @see https://api.slack.com/events/im_marked
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_marked.json
-        # on :im_marked do |data|
-
-        # Bulk updates were made to a DM channel's history.
-        # @see https://api.slack.com/events/im_history_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_history_changed.json
-        # on :im_history_changed do |data|
-
-        # A direct message channel was created.
-        # @see https://api.slack.com/events/im_created
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_created.json
-        # on :im_created do |data|
-
-        # You closed a direct message channel.
-        # @see https://api.slack.com/events/im_close
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_close.json
-        # on :im_close do |data|
-
-        # A private group was unarchived.
-        # @see https://api.slack.com/events/group_unarchive
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_unarchive.json
-        # on :group_unarchive do |data|
-
-        # A private group was renamed.
-        # @see https://api.slack.com/events/group_rename
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_rename.json
-        # on :group_rename do |data|
-
-        # You opened a group channel.
-        # @see https://api.slack.com/events/group_open
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_open.json
-        # on :group_open do |data|
-
-        # A private group read marker was updated.
-        # @see https://api.slack.com/events/group_marked
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_marked.json
-        # on :group_marked do |data|
-
-        # You left a private group.
-        # @see https://api.slack.com/events/group_left
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_left.json
-        # on :group_left do |data|
-
-        # You joined a private group.
-        # @see https://api.slack.com/events/group_joined
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_joined.json
-        # on :group_joined do |data|
-
-        # Bulk updates were made to a group's history.
-        # @see https://api.slack.com/events/group_history_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_history_changed.json
-        # on :group_history_changed do |data|
-
-        # You closed a group channel.
-        # @see https://api.slack.com/events/group_close
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_close.json
-        # on :group_close do |data|
-
-        # A private group was archived.
-        # @see https://api.slack.com/events/group_archive
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_archive.json
-        # on :group_archive do |data|
-
-        # A file was unshared.
-        # @see https://api.slack.com/events/file_unshared
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_unshared.json
-        # on :file_unshared do |data|
-
-        # A file was shared.
-        # @see https://api.slack.com/events/file_shared
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_shared.json
-        # on :file_shared do |data|
-
-        # A file was made public.
-        # @see https://api.slack.com/events/file_public
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_public.json
-        # on :file_public do |data|
-
-        # A file was made private.
-        # @see https://api.slack.com/events/file_private
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_private.json
-        # on :file_private do |data|
-
-        # A file was deleted.
-        # @see https://api.slack.com/events/file_deleted
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_deleted.json
-        # on :file_deleted do |data|
-
-        # A file was created.
-        # @see https://api.slack.com/events/file_created
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_created.json
-        # on :file_created do |data|
-
-        # A file comment was edited.
-        # @see https://api.slack.com/events/file_comment_edited
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_edited.json
-        # on :file_comment_edited do |data|
-
-        # A file comment was deleted.
-        # @see https://api.slack.com/events/file_comment_deleted
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_deleted.json
-        # on :file_comment_deleted do |data|
-
-        # A file comment was added.
-        # @see https://api.slack.com/events/file_comment_added
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_added.json
-        # on :file_comment_added do |data|
-
-        # A file was changed.
-        # @see https://api.slack.com/events/file_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_change.json
-        # on :file_change do |data|
-
-        # A team custom emoji has been added or changed.
-        # @see https://api.slack.com/events/emoji_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/emoji_changed.json
-        # on :emoji_changed do |data|
-
-        # Do not Disturb settings changed for a team member.
-        # @see https://api.slack.com/events/dnd_updated_user
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/dnd_updated_user.json
-        # on :dnd_updated_user do |data|
-
-        # Do not Disturb settings changed for the current user.
-        # @see https://api.slack.com/events/dnd_updated
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/dnd_updated.json
-        # on :dnd_updated do |data|
-
-        # A team slash command has been added or changed.
-        # @see https://api.slack.com/events/commands_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/commands_changed.json
-        # on :commands_changed do |data|
-
-        # A team channel was unarchived.
-        # @see https://api.slack.com/events/channel_unarchive
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_unarchive.json
-        # on :channel_unarchive do |data|
-
-        # A team channel was renamed.
-        # @see https://api.slack.com/events/channel_rename
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_rename.json
-        # on :channel_rename do |data|
-
-        # Your channel read marker was updated.
-        # @see https://api.slack.com/events/channel_marked
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_marked.json
-        # on :channel_marked do |data|
-
-        # You left a channel.
-        # @see https://api.slack.com/events/channel_left
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_left.json
-        # on :channel_left do |data|
-
-        # You joined a channel.
-        # @see https://api.slack.com/events/channel_joined
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_joined.json
-        # on :channel_joined do |data|
-
-        # Bulk updates were made to a channel's history.
-        # @see https://api.slack.com/events/channel_history_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_history_changed.json
-        # on :channel_history_changed do |data|
-
-        # A team channel was deleted.
-        # @see https://api.slack.com/events/channel_deleted
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_deleted.json
-        # on :channel_deleted do |data|
-
-        # A team channel was created.
-        # @see https://api.slack.com/events/channel_created
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_created.json
-        # on :channel_created do |data|
-
-        # A team channel was archived.
-        # @see https://api.slack.com/events/channel_archive
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_archive.json
-        # on :channel_archive do |data|
-
-        # An integration bot was changed.
-        # @see https://api.slack.com/events/bot_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/bot_changed.json
-        # on :bot_changed do |data|
-
-        # An integration bot was added.
-        # @see https://api.slack.com/events/bot_added
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/bot_added.json
-        # on :bot_added do |data|
-
-        # The list of accounts a user is signed into has changed.
-        # @see https://api.slack.com/events/accounts_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/accounts_changed.json
-        # on :accounts_changed do |data|
-
-        # The team domain has changed.
-        # @see https://api.slack.com/events/team_domain_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_domain_change.json
-        on :team_domain_change do |data|
-          team.url = data.url
-          team.domain = data.domain
-        end
-
-        # The team is being migrated between servers.
-        # @see https://api.slack.com/events/team_migration_started
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_migration_started.json
-        # on :team_migration_started do |data|
-
-        # The team billing plan has changed.
-        # @see https://api.slack.com/events/team_plan_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_plan_change.json
-        on :team_plan_change do |data|
-          team.plan = data.plan
-        end
-
-        # A team preference has been updated.
-        # @see https://api.slack.com/events/team_pref_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_pref_change.json
-        on :team_pref_change do |data|
-          team.prefs ||= {}
-          team.prefs[data.name] = data.value
-        end
-
-        # Team profile fields have been updated.
-        # @see https://api.slack.com/events/team_profile_change
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_change.json
-        # on :team_profile_change do |data|
-
-        # Team profile fields have been deleted.
-        # @see https://api.slack.com/events/team_profile_delete
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_delete.json
-        # on :team_profile_delete do |data|
-
-        # Team profile fields have been reordered.
-        # @see https://api.slack.com/events/team_profile_reorder
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_reorder.json
-        # on :team_profile_reorder do |data|
-
-        # The team name has changed.
-        # @see https://api.slack.com/events/team_rename
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_rename.json
-        on :team_rename do |data|
-          team.name = data.name
-        end
-
-        # The team email domain has changed.
-        # @see https://api.slack.com/events/email_domain_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/email_domain_changed.json
-        on :email_domain_changed do |data|
-          team.email_domain = data.email_domain
-        end
       end
     end
   end

--- a/lib/slack/real_time/stores/store.rb
+++ b/lib/slack/real_time/stores/store.rb
@@ -55,119 +55,19 @@ module Slack
 
         ### RealTime Events
 
-        # A user's status has changed.
-        # @see https://api.slack.com/events/user_status_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_status_changed.json
-        # on :user_status_changed do |data|
-
-        # A user's profile data has changed.
-        # @see https://api.slack.com/events/user_profile_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_profile_changed.json
-        # on :user_profile_changed do |data|
-
-        # A user's huddle status has changed.
-        # @see https://api.slack.com/events/user_huddle_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_huddle_changed.json
-        # on :user_huddle_changed do |data|
-
-        # A shared channel invite was sent to a Slack user.
-        # @see https://api.slack.com/events/shared_channel_invite_received
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/shared_channel_invite_received.json
-        # on :shared_channel_invite_received do |data|
-
-        # An enterprise grid migration has started on an external workspace..
-        # @see https://api.slack.com/events/external_org_migration_started
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_started.json
-        # on :external_org_migration_started do |data|
-
-        # An enterprise grid migration has finished on an external workspace..
-        # @see https://api.slack.com/events/external_org_migration_finished
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_finished.json
-        # on :external_org_migration_finished do |data|
-
-        # A private channel was deleted.
-        # @see https://api.slack.com/events/group_deleted
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_deleted.json
-        # on :group_deleted do |data|
-
-        # Determine the current presence status for a list of users.
-        # @see https://api.slack.com/events/presence_query
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_query.json
-        # on :presence_query do |data|
-
-        # The membership of an existing User Group has changed.
-        # @see https://api.slack.com/events/subteam_members_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_members_changed.json
-        # on :subteam_members_changed do |data|
-
-        # Subscribe to presence events for the specified users.
-        # @see https://api.slack.com/events/presence_sub
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_sub.json
-        # on :presence_sub do |data|
-
-        # A user left a public or private channel.
-        # @see https://api.slack.com/events/member_left_channel
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_left_channel.json
-        # on :member_left_channel do |data|
-
-        # A user joined a public or private channel.
-        # @see https://api.slack.com/events/member_joined_channel
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_joined_channel.json
-        # on :member_joined_channel do |data|
-
-        # The server intends to close the connection soon..
-        # @see https://api.slack.com/events/goodbye
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/goodbye.json
-        # on :goodbye do |data|
-
-        # Verifies ownership of an Events API Request URL.
-        # @see https://api.slack.com/events/url_verification
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/url_verification.json
-        # on :url_verification do |data|
-
-        # A message was posted in a multiparty direct message channel.
-        # @see https://api.slack.com/events/message.mpim
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/message.mpim.json
-        # on :message.mpim do |data|
-
-        # A message was posted in a direct message channel.
-        # @see https://api.slack.com/events/message.im
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/message.im.json
-        # on :message.im do |data|
-
-        # A message was posted to a private channel.
-        # @see https://api.slack.com/events/message.groups
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/message.groups.json
-        # on :message.groups do |data|
-
-        # A message was posted to a channel.
-        # @see https://api.slack.com/events/message.channels
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/message.channels.json
-        # on :message.channels do |data|
-
-        # A direct message read marker was updated.
-        # @see https://api.slack.com/events/im_marked
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_marked.json
-        # on :im_marked do |data|
-
-        # Bulk updates were made to a DM channel's history.
-        # @see https://api.slack.com/events/im_history_changed
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_history_changed.json
-        # on :im_history_changed do |data|
-
         # The list of accounts a user is signed into has changed.
         # @see https://api.slack.com/events/accounts_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/accounts_changed.json
         # on :accounts_changed do |data|
 
-        # An integration bot was added.
+        # A bot user was added.
         # @see https://api.slack.com/events/bot_added
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/bot_added.json
         on :bot_added do |data|
           bots[data.bot.id] = Models::Bot.new(data.bot)
         end
 
-        # An integration bot was changed.
+        # A bot user was changed.
         # @see https://api.slack.com/events/bot_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/bot_changed.json
         on :bot_changed do |data|
@@ -175,7 +75,7 @@ module Slack
           bot&.merge!(data.bot)
         end
 
-        # A team channel was archived.
+        # A channel was archived.
         # @see https://api.slack.com/events/channel_archive
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_archive.json
         on :channel_archive do |data|
@@ -183,7 +83,7 @@ module Slack
           channel.is_archived = true if channel
         end
 
-        # A team channel was created.
+        # A channel was created.
         # @see https://api.slack.com/events/channel_created
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_created.json
         on :channel_created do |data|
@@ -191,7 +91,7 @@ module Slack
           channels[channel.id] = channel
         end
 
-        # A team channel was deleted.
+        # A channel was deleted.
         # @see https://api.slack.com/events/channel_deleted
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_deleted.json
         on :channel_deleted do |data|
@@ -229,7 +129,7 @@ module Slack
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_marked.json
         # on :channel_marked do |data|
 
-        # A team channel was renamed.
+        # A channel was renamed.
         # @see https://api.slack.com/events/channel_rename
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_rename.json
         on :channel_rename do |data|
@@ -237,7 +137,7 @@ module Slack
           channel.name = data.channel.name if channel
         end
 
-        # A team channel was unarchived.
+        # A channel was unarchived.
         # @see https://api.slack.com/events/channel_unarchive
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/channel_unarchive.json
         on :channel_unarchive do |data|
@@ -245,7 +145,7 @@ module Slack
           channel.is_archived = false if channel
         end
 
-        # A team slash command has been added or changed.
+        # A slash command has been added or changed.
         # @see https://api.slack.com/events/commands_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/commands_changed.json
         # on :commands_changed do |data|
@@ -255,22 +155,32 @@ module Slack
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/dnd_updated.json
         # on :dnd_updated do |data|
 
-        # Do not Disturb settings changed for a team member.
+        # Do not Disturb settings changed for a member.
         # @see https://api.slack.com/events/dnd_updated_user
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/dnd_updated_user.json
         # on :dnd_updated_user do |data|
 
-        # The team email domain has changed.
+        # The workspace email domain has changed.
         # @see https://api.slack.com/events/email_domain_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/email_domain_changed.json
         on :email_domain_changed do |data|
           team.email_domain = data.email_domain
         end
 
-        # A team custom emoji has been added or changed.
+        # A custom emoji has been added or changed.
         # @see https://api.slack.com/events/emoji_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/emoji_changed.json
         # on :emoji_changed do |data|
+
+        # An enterprise grid migration has finished on an external workspace..
+        # @see https://api.slack.com/events/external_org_migration_finished
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_finished.json
+        # on :external_org_migration_finished do |data|
+
+        # An enterprise grid migration has started on an external workspace..
+        # @see https://api.slack.com/events/external_org_migration_started
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/external_org_migration_started.json
+        # on :external_org_migration_started do |data|
 
         # A file was changed.
         # @see https://api.slack.com/events/file_change
@@ -280,7 +190,7 @@ module Slack
         # A file comment was added.
         # @see https://api.slack.com/events/file_comment_added
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_comment_added.json
-        # on :file_comment_added do |data| do
+        # on :file_comment_added do |data|
 
         # A file comment was deleted.
         # @see https://api.slack.com/events/file_comment_deleted
@@ -302,11 +212,6 @@ module Slack
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_deleted.json
         # on :file_deleted do |data|
 
-        # A file was made private.
-        # @see https://api.slack.com/events/file_private
-        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_private.json
-        # on :file_private do |data|
-
         # A file was made public.
         # @see https://api.slack.com/events/file_public
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_public.json
@@ -322,7 +227,12 @@ module Slack
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/file_unshared.json
         # on :file_unshared do |data|
 
-        # A private group was archived.
+        # The server intends to close the connection soon..
+        # @see https://api.slack.com/events/goodbye
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/goodbye.json
+        # on :goodbye do |data|
+
+        # A private channel was archived.
         # @see https://api.slack.com/events/group_archive
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_archive.json
         on :group_archive do |data|
@@ -330,26 +240,31 @@ module Slack
           channel.is_archived = true if channel
         end
 
-        # You closed a group channel.
+        # You closed a private channel.
         # @see https://api.slack.com/events/group_close
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_close.json
         on :group_close do |data|
           groups[data.channel].is_open = false
         end
 
-        # Bulk updates were made to a group's history.
+        # A private channel was deleted.
+        # @see https://api.slack.com/events/group_deleted
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_deleted.json
+        # on :group_deleted do |data|
+
+        # Bulk updates were made to a private channel's history.
         # @see https://api.slack.com/events/group_history_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_history_changed.json
         # on :group_history_changed do |data|
 
-        # You joined a private group.
+        # You joined a private channel.
         # @see https://api.slack.com/events/group_joined
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_joined.json
         on :group_joined do |data|
           groups[data.channel.id] = Models::Channel.new(data.channel)
         end
 
-        # You left a private group.
+        # You left a private channel.
         # @see https://api.slack.com/events/group_left
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_left.json
         on :group_left do |data|
@@ -357,19 +272,19 @@ module Slack
           channel.members.delete(self.self.id) if channel&.key?(:members)
         end
 
-        # A private group read marker was updated.
+        # A private channel read marker was updated.
         # @see https://api.slack.com/events/group_marked
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_marked.json
         # on :group_marked do |data|
 
-        # You opened a group channel.
+        # You created a group DM.
         # @see https://api.slack.com/events/group_open
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_open.json
         on :group_open do |data|
           groups[data.channel].is_open = true
         end
 
-        # A private group was renamed.
+        # A private channel was renamed.
         # @see https://api.slack.com/events/group_rename
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_rename.json
         on :group_rename do |data|
@@ -377,7 +292,7 @@ module Slack
           channel.name = data.channel.name if channel
         end
 
-        # A private group was unarchived.
+        # A private channel was unarchived.
         # @see https://api.slack.com/events/group_unarchive
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/group_unarchive.json
         on :group_unarchive do |data|
@@ -385,7 +300,12 @@ module Slack
           channel.is_archived = false if channel
         end
 
-        # You closed a direct message channel.
+        # The client has successfully connected to the server.
+        # @see https://api.slack.com/events/hello
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/hello.json
+        # on :hello do |data|
+
+        # You closed a DM.
         # @see https://api.slack.com/events/im_close
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_close.json
         on :im_close do |data|
@@ -394,14 +314,14 @@ module Slack
           ims[data.channel].is_open = false
         end
 
-        # A direct message channel was created.
+        # A DM was created.
         # @see https://api.slack.com/events/im_created
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_created.json
         on :im_created do |data|
           ims[data.channel.id] = Models::Im.new(data.channel)
         end
 
-        # Bulk updates were made to a DM channel's history.
+        # Bulk updates were made to a DM's history.
         # @see https://api.slack.com/events/im_history_changed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_history_changed.json
         # on :im_history_changed do |data|
@@ -411,7 +331,7 @@ module Slack
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_marked.json
         # on :im_marked do |data|
 
-        # You opened a direct message channel.
+        # You opened a DM.
         # @see https://api.slack.com/events/im_open
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/im_open.json
         on :im_open do |data|
@@ -426,6 +346,16 @@ module Slack
         on :manual_presence_change do |data|
           self.self.presence = data.presence
         end
+
+        # A user joined a public channel, private channel or MPDM..
+        # @see https://api.slack.com/events/member_joined_channel
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_joined_channel.json
+        # on :member_joined_channel do |data|
+
+        # A user left a public or private channel.
+        # @see https://api.slack.com/events/member_left_channel
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/member_left_channel.json
+        # on :member_left_channel do |data|
 
         # A pin was added to a channel.
         # @see https://api.slack.com/events/pin_added
@@ -445,7 +375,7 @@ module Slack
           self.self.prefs[data.name] = data.value
         end
 
-        # A team member's presence changed.
+        # A member's presence changed.
         # @see https://api.slack.com/events/presence_change
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_change.json
         on :presence_change do |data|
@@ -453,12 +383,22 @@ module Slack
           user.presence = data.presence if user
         end
 
-        # A team member has added an emoji reaction to an item.
+        # Determine the current presence status for a list of users.
+        # @see https://api.slack.com/events/presence_query
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_query.json
+        # on :presence_query do |data|
+
+        # Subscribe to presence events for the specified users.
+        # @see https://api.slack.com/events/presence_sub
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/presence_sub.json
+        # on :presence_sub do |data|
+
+        # A member has added an emoji reaction to an item.
         # @see https://api.slack.com/events/reaction_added
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reaction_added.json
         # on :reaction_added do |data|
 
-        # A team member removed an emoji reaction.
+        # A member removed an emoji reaction.
         # @see https://api.slack.com/events/reaction_removed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reaction_removed.json
         # on :reaction_removed do |data|
@@ -468,37 +408,47 @@ module Slack
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/reconnect_url.json
         # on :reconnect_url do |data|
 
-        # A team member has starred an item.
+        # A shared channel invite was sent to a Slack user.
+        # @see https://api.slack.com/events/shared_channel_invite_received
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/shared_channel_invite_received.json
+        # on :shared_channel_invite_received do |data|
+
+        # A member has starred an item.
         # @see https://api.slack.com/events/star_added
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/star_added.json
         # on :star_added do |data|
 
-        # A team member removed a star.
+        # A member removed a star.
         # @see https://api.slack.com/events/star_removed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/star_removed.json
         # on :star_removed do |data|
 
-        # A user group has been added to the team.
+        # A User Group has been added to the workspace.
         # @see https://api.slack.com/events/subteam_created
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_created.json
         # on :subteam_created do |data|
 
-        # You have been added to a user group.
+        # The membership of an existing User Group has changed.
+        # @see https://api.slack.com/events/subteam_members_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_members_changed.json
+        # on :subteam_members_changed do |data|
+
+        # You have been added to a User Group.
         # @see https://api.slack.com/events/subteam_self_added
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_self_added.json
         # on :subteam_self_added do |data|
 
-        # You have been removed from a user group.
+        # You have been removed from a User Group.
         # @see https://api.slack.com/events/subteam_self_removed
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_self_removed.json
         # on :subteam_self_removed do |data|
 
-        # An existing user group has been updated or its members changed.
+        # An existing User Group has been updated or its members changed.
         # @see https://api.slack.com/events/subteam_updated
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/subteam_updated.json
         # on :subteam_updated do |data|
 
-        # The team domain has changed.
+        # The workspace domain has changed.
         # @see https://api.slack.com/events/team_domain_change
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_domain_change.json
         on :team_domain_change do |data|
@@ -506,26 +456,26 @@ module Slack
           team.domain = data.domain
         end
 
-        # A new team member has joined.
+        # A new member has joined.
         # @see https://api.slack.com/events/team_join
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_join.json
         on :team_join do |data|
           users[data.user.id] = Models::User.new(data.user)
         end
 
-        # The team is being migrated between servers.
+        # The workspace is being migrated between servers.
         # @see https://api.slack.com/events/team_migration_started
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_migration_started.json
         # on :team_migration_started do |data|
 
-        # The team billing plan has changed.
+        # The account billing plan has changed.
         # @see https://api.slack.com/events/team_plan_change
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_plan_change.json
         on :team_plan_change do |data|
           team.plan = data.plan
         end
 
-        # A team preference has been updated.
+        # A preference has been updated.
         # @see https://api.slack.com/events/team_pref_change
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_pref_change.json
         on :team_pref_change do |data|
@@ -533,34 +483,49 @@ module Slack
           team.prefs[data.name] = data.value
         end
 
-        # Team profile fields have been updated.
+        # The workspace profile fields have been updated.
         # @see https://api.slack.com/events/team_profile_change
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_change.json
         # on :team_profile_change do |data|
 
-        # Team profile fields have been deleted.
+        # The workspace profile fields have been deleted.
         # @see https://api.slack.com/events/team_profile_delete
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_delete.json
         # on :team_profile_delete do |data|
 
-        # Team profile fields have been reordered.
+        # The workspace profile fields have been reordered.
         # @see https://api.slack.com/events/team_profile_reorder
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_profile_reorder.json
         # on :team_profile_reorder do |data|
 
-        # The team name has changed.
+        # The workspace name has changed.
         # @see https://api.slack.com/events/team_rename
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/team_rename.json
         on :team_rename do |data|
           team.name = data.name
         end
 
-        # A team member's data has changed.
+        # A member's data has changed.
         # @see https://api.slack.com/events/user_change
         # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_change.json
         on :user_change do |data|
           users[data.user.id] = Models::User.new(data.user)
         end
+
+        # A user's huddle status has changed.
+        # @see https://api.slack.com/events/user_huddle_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_huddle_changed.json
+        # on :user_huddle_changed do |data|
+
+        # A user's profile data has changed.
+        # @see https://api.slack.com/events/user_profile_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_profile_changed.json
+        # on :user_profile_changed do |data|
+
+        # A user's status has changed.
+        # @see https://api.slack.com/events/user_status_changed
+        # @see https://github.com/slack-ruby/slack-api-ref/blob/master/events/user_status_changed.json
+        # on :user_status_changed do |data|
 
         # A channel member is typing a message.
         # @see https://api.slack.com/events/user_typing

--- a/lib/slack/web/api/endpoints/files.rb
+++ b/lib/slack/web/api/endpoints/files.rb
@@ -54,7 +54,7 @@ module Slack
           end
 
           #
-          # Gets a URL for an edge external upload
+          # Gets a URL for an edge external file upload
           #
           # @option options [string] :filename
           #   Name of the file being uploaded.

--- a/lib/tasks/real_time.rake
+++ b/lib/tasks/real_time.rake
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
-# largely from https://github.com/aki017/slack-ruby-gem
+
 require 'json-schema'
 require 'erubis'
 
+# largely from https://github.com/aki017/slack-ruby-gem
 namespace :slack do
   namespace :real_time do
     namespace :api do
@@ -16,39 +17,60 @@ namespace :slack do
           name = File.basename(path, '.json')
           parsed = JSON.parse(File.read(path))
           JSON::Validator.validate(event_schema, parsed, insert_defaults: true)
-          next if %w[message hello].include?(name)
+          next if name == 'message'
 
           result[name] = parsed
         end
 
-        event_handler_template =
-          Erubis::Eruby.new(File.read('lib/slack/real_time/api/templates/event_handler.erb'))
+        hook_template = Erubis::Eruby.new(File.read('lib/slack/real_time/api/templates/event_handler.erb'))
         Dir.glob('lib/slack/real_time/stores/**/*.rb').each do |store_file|
           next if File.basename(store_file) == 'base.rb'
 
-          STDOUT.write "#{File.basename(store_file)}:"
+          STDOUT.write "#{File.basename(store_file)}: "
 
           store_file_contents = File.read(store_file)
 
-          events.each_pair do |event_name, event_data|
-            if store_file_contents.include?("on :#{event_name} do")
-              STDOUT.write('.')
-            else
-              STDOUT.write('x')
-              rendered_event_handler = event_handler_template.result(
-                name: event_data['name'],
-                desc: event_data['desc']
-              )
-
-              store_file_contents.gsub!(
-                REAL_TIME_EVENTS_MARKER,
-                REAL_TIME_EVENTS_MARKER +
-                  "\n\n" +
-                  rendered_event_handler.rstrip
-              )
-            end
+          unless store_file_contents.include?(REAL_TIME_EVENTS_MARKER)
+            puts "missing '#{REAL_TIME_EVENTS_MARKER}' line; skipping."
+            next
           end
 
+          # Extract current hook implementations from the store class
+          hooks = {}
+          hook_matcher = /
+            (?:^[[:blank:]]*\R)+                                                     # At least one blank line
+            (?:^[[:blank:]]*\#.*\R)*                                                 # Optional preceding comments
+            (?<hook>                                                                 # on :event do |data|
+              ^(?<padding>[[:blank:]]+)\#\ *on\ :(?<event>\w+)\ do\ \|[\w, ]+\|\ *\R # Commented hook
+              (?>^\k<padding>\#.*\R)*                                                # Extra comments
+              |
+              ^(?<padding>[[:blank:]]+)on\ :(?<event>\w+)\ do\ \|[\w, ]+\|\ *\R      # Active hook
+              [\s\S]*?                                                               # Inside block
+              (?>^\k<padding>end[[:blank:]]*\R)                                      # End of block
+            )
+          /x
+          store_file_contents.gsub!(hook_matcher) do
+            hook, event = Regexp.last_match.values_at(:hook, :event)
+            hooks[event] = hook
+            nil
+          end
+
+          # Render latest event documentation with current hook implementations
+          rendered_hooks = events.map do |event_name, event_data|
+            STDOUT.write(hooks.key?(event_name) ? '.' : 'x')
+
+            hook_template.result(
+              name: event_data['name'],
+              desc: event_data['desc'],
+              hook: hooks[event_name]
+            ).rstrip
+          end
+
+          # Insert updated event hooks under RealTime Events marker
+          store_file_contents.gsub!(
+            REAL_TIME_EVENTS_MARKER,
+            [REAL_TIME_EVENTS_MARKER, *rendered_hooks].join("\n\n")
+          )
           File.write(store_file, store_file_contents)
 
           puts ' done.'

--- a/lib/tasks/web.rake
+++ b/lib/tasks/web.rake
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
-# largely from https://github.com/aki017/slack-ruby-gem
+
 require 'json-schema'
 require 'erubis'
 require 'active_support'
 require 'active_support/core_ext'
 
+# largely from https://github.com/aki017/slack-ruby-gem
 namespace :slack do
   namespace :web do
     namespace :api do


### PR DESCRIPTION
The `slack:real_time:api:update` task currently doesn't touch previous hooks and only prepends new event handler templates at the top of the store. The result is that many of the hooks currently in the stores are for Slack events that no longer exist or have outdated documentation. Additionally, there is no consistent ordering.

This PR makes the task more intelligent to extract all the current hooks and reuse only the hooks themselves while always generating fresh documentation and arranging the hooks in alphabetical order. Any hooks not matching the current Slack API ref are discarded.

This sets up updating some hook implementations for changes in #423