### PR TITLE
Rename GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Rubocop
+name: Lint
 on: [push, pull_request]
 jobs:
   rubocop:

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -1,4 +1,4 @@
-name: PR Linter
+name: PR Lint
 on: pull_request
 jobs:
   danger:


### PR DESCRIPTION
Following up on https://github.com/slack-ruby/slack-ruby-client/pull/427#discussion_r998588435, renaming workflows to match [slack-api-ref](https://github.com/slack-ruby/slack-api-ref/blob/master/.github/workflows/lint.yml) and allow additional linters to be added to the same workflow.