### PR TITLE
Remove websocker-driver dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.0.1 (Next)
+### 2.1.0 (Next)
 
 * Your contribution here.
 * [#434](https://github.com/slack-ruby/slack-ruby-client/pull/434): Fix incompatibility with Faraday >= 2.7.0 and GLI usage in the `slack` script - [@blowfishpro](https://github.com/blowfishpro).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.1.0 (Next)
 
 * Your contribution here.
+* [#436](https://github.com/slack-ruby/slack-ruby-client/pull/436): Remove dependency on unused websocket-driver - [@blowfishpro](https://github.com/blowfishpro).
 * [#434](https://github.com/slack-ruby/slack-ruby-client/pull/434): Fix incompatibility with Faraday >= 2.7.0 and GLI usage in the `slack` script - [@blowfishpro](https://github.com/blowfishpro).
 
 ### 2.0.0 (2022/10/19)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday-multipart'
   s.add_dependency 'gli'
   s.add_dependency 'hashie'
-  s.add_dependency 'websocket-driver'
   s.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
It appears that this should never have been here - It was required to support some celluloid code, but celluloid was optional anyway, and the celluloid code has since been removed.

Resolves #431