### PR TITLE
Only run integration tests in integration_test job

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,8 +1,25 @@
 name: Integration Tests
 on: push
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      secret-exists: ${{ steps.check-secret.outputs.defined }}
+    steps:
+      - name: Check for SLACK_API_TOKEN availability
+        id: check-secret
+        shell: bash
+        run: |
+          if [ "${{ secrets.SLACK_API_TOKEN }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   test:
     runs-on: ubuntu-latest
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secret-exists == 'true'
     strategy:
       matrix:
         entry:
@@ -21,6 +38,8 @@ jobs:
           CONCURRENCY: ${{ matrix.entry.concurrency }}
           SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
           RACK_ENV: test
+          SPEC: "--pattern spec/**/integration/*_spec.rb"
+          SPEC_OPTS: "--pattern spec/**/integration/*_spec.rb"
         run: |
           bundle install
           bundle exec rake

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,25 +1,25 @@
 name: Integration Tests
 on: push
 jobs:
-  check-secret:
+  check-slack-api-token:
     runs-on: ubuntu-latest
     outputs:
-      secret-exists: ${{ steps.check-secret.outputs.defined }}
+      SLACK_API_TOKEN_EXISTS: ${{ steps.check-slack-api-token.outputs.SLACK_API_TOKEN_EXISTS }}
     steps:
       - name: Check for SLACK_API_TOKEN availability
-        id: check-secret
+        id: check-slack-api-token
         shell: bash
         run: |
           if [ "${{ secrets.SLACK_API_TOKEN }}" != '' ]; then
-            echo "defined=true" >> $GITHUB_OUTPUT;
+            echo "SLACK_API_TOKEN_EXISTS=true" >> $GITHUB_OUTPUT;
           else
-            echo "defined=false" >> $GITHUB_OUTPUT;
+            echo "SLACK_API_TOKEN_EXISTS=false" >> $GITHUB_OUTPUT;
           fi
 
   test:
     runs-on: ubuntu-latest
-    needs: [check-secret]
-    if: needs.check-secret.outputs.secret-exists == 'true'
+    needs: [check-slack-api-token]
+    if: needs.check-slack-api-token.outputs.SLACK_API_TOKEN_EXISTS == 'true'
     strategy:
       matrix:
         entry:


### PR DESCRIPTION
This:

1) skips the integration test job entirely in GitHub Actions if there isn't a Slack token in secrets.

It's particularly annoying to use the absence of a secret to control job flow. This is based on the answer here https://stackoverflow.com/questions/70249519/how-to-check-if-a-secret-variable-is-empty-in-if-conditional-github-actions

I went with the option of skipping the job entirely so it doesn't need to even checkout or install dependencies if the secret isn't there, but can be convinced this isn't the right approach.

Hidden secret, allows integration tests:

<img width="445" alt="Screen Shot 2023-03-15 at 11 18 56 AM" src="https://user-images.githubusercontent.com/3457341/225389663-4993608a-2d3e-493d-85e3-0758369476d7.png">

No secret, skips integration tests:
<img width="663" alt="Screen Shot 2023-03-15 at 11 19 11 AM" src="https://user-images.githubusercontent.com/3457341/225389673-8fa179d8-bda5-4486-aa67-6d0dcf5e1c90.png">

2) only runs the `integration` directory tests on this job

I'm not 100% sure why both `SPEC` and `SPEC_OPTS` are required here, but it doesn't work with either/or but only both

Closes #444