### PR TITLE
Add workflow for automatic API updates

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -1,0 +1,51 @@
+name: Update API from slack-api-ref
+on:
+  schedule:
+    - cron: "15 23 * * *"
+jobs:
+  update-api:
+    if: ${{ github.repository == 'slack-ruby/slack-ruby-client' }}
+    runs-on: ubuntu-latest
+    permissions: 
+      contents: write
+      pull-requests: write
+    steps:
+      # Setup and potential creation of initial pull request
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive  
+      - name: Get current date
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Make a file to trigger an initial pull request
+        run : echo "${{ env.CURRENT_DATE }}" > file.txt
+      - name: Create initial pull request
+        id: create-initial-pull-request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: update-api
+          base: master
+      # Generation of new API methods and update of pull request
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Update API from slack-api-ref
+        run: bundle exec rake slack:api:update
+      - name: Remove files added by setup-ruby
+        run: rm -rf vendor
+      - name: Update changelog
+        run: |
+          ruby -i -pe 'sub(/\* Your contribution here\./, "* Your contribution here.\n* [#${{ steps.create-initial-pull-request.outputs.pull-request-number }}](https://github.com/slack-ruby/slack-ruby-client/pull/${{ steps.create-initial-pull-request.outputs.pull-request-number }}): Update Slack API (${{ env.CURRENT_DATE }}) - [@slack-ruby-client](https://github.com/slack-ruby/slack-ruby-client).")' CHANGELOG.md
+      - name: Create pull request with changelog
+        id: update-changelog
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: Update API from slack-api-ref (${{ env.CURRENT_DATE }})
+          title: Update API from slack-api-ref (${{ env.CURRENT_DATE }})
+          body: |
+            Update API from [slack-api-ref](https://github.com/slack-ruby/slack-api-ref) (${{ env.CURRENT_DATE }})
+          branch: update-api
+          base: master
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>

--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -22,7 +22,7 @@ jobs:
         id: create-initial-pull-request
         uses: peter-evans/create-pull-request@v4
         with:
-          branch: update-api
+          branch: automated-api-update
           base: master
       # Generation of new API methods and update of pull request
       - name: Set up Ruby
@@ -45,7 +45,7 @@ jobs:
           title: Update API from slack-api-ref (${{ env.CURRENT_DATE }})
           body: |
             Update API from [slack-api-ref](https://github.com/slack-ruby/slack-api-ref) (${{ env.CURRENT_DATE }})
-          branch: update-api
+          branch: automated-api-update
           base: master
           committer: GitHub <noreply@github.com>
           author: GitHub <noreply@github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.2.0 (Next)
 
 * Your contribution here.
+* [#458](https://github.com/slack-ruby/slack-ruby-client/pull/458): Add workflow for automatic API updates - [@duffn](https://github.com/duffn).
 * [#455](https://github.com/slack-ruby/slack-ruby-client/pull/455): Update Slack API: Added pagination to `team.accessLogs` and `AppsDatastore` methods - [@marfoldi](https://github.com/marfoldi).
 * [#454](https://github.com/slack-ruby/slack-ruby-client/pull/454): Added `Slack::Messages::Formatting#escape` - [@marfoldi](https://github.com/marfoldi).
 * [#452](https://github.com/slack-ruby/slack-ruby-client/pull/452): Automatically generate Web API multi-argument requirements from docs - [@jmanian](https://github.com/jmanian).


### PR DESCRIPTION
This adds a workflow that automatically updates the API from `slack-api-ref` and creates a running PR with changes per #456.

## Notes

- the repo will need to be updated to allow Actions to create pull requests in settings

<img width="844" alt="Screen Shot 2023-03-25 at 1 25 29 PM" src="https://user-images.githubusercontent.com/3457341/227737386-364a4a3e-51f7-4937-9e59-2678edfdef7d.png">

- this setup section is silly but if there’s no PR, need to get the PR number in order to include it in the changelog: [`master...duffn:slack-ruby-client:duffn/automate-api-updates?expand=1`#diff-75bb0e4f3b](https://github.com/slack-ruby/slack-ruby-client/compare/master...duffn:slack-ruby-client:duffn/automate-api-updates?expand=1#diff-75bb0e4f3b406b915ef0f52ecf5037f3b057ce8a40a6101f400cec65fcf87171R13-R26)
- runs 1 hour after the `slack-api-ref` cronjob
- will either create or update an already existing PR from the `automated-api-update` branch

## Example

This works here, but it wouldn't surprise me if this didn't quite work as expected after merging here, but can fix forward.

https://github.com/duffn/slack-ruby-client-dev/pull/5

Closes #456