### PR TITLE
Remove extra steps in automated API updates Action

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -10,23 +10,11 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      # Setup and potential creation of initial pull request
       - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Config git to rebase
         run: git config --global pull.rebase true
-      - name: Get current date
-        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Make a file to trigger an initial pull request
-        run: echo "${{ env.CURRENT_DATE }}" > file.txt
-      - name: Create initial pull request
-        id: create-initial-pull-request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          branch: automated-api-update
-          base: master
-      # Generation of new API methods and update of pull request
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -36,17 +24,14 @@ jobs:
         run: bundle exec rake slack:api:update
       - name: Remove files added by setup-ruby
         run: rm -rf vendor
-      - name: Update changelog
-        run: |
-          ruby -i -pe 'sub(/\* Your contribution here\./, "* Your contribution here.\n* [#${{ steps.create-initial-pull-request.outputs.pull-request-number }}](https://github.com/slack-ruby/slack-ruby-client/pull/${{ steps.create-initial-pull-request.outputs.pull-request-number }}): Update Slack API (${{ env.CURRENT_DATE }}) - [@slack-ruby-client](https://github.com/slack-ruby/slack-ruby-client).")' CHANGELOG.md
-      - name: Create pull request with changelog
-        id: update-changelog
+      - name: Create pull request
+        id: create-pull-request
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: Update API from slack-api-ref (${{ env.CURRENT_DATE }})
-          title: Update API from slack-api-ref (${{ env.CURRENT_DATE }})
+          commit-message: Update API from slack-api-ref
+          title: Update API from slack-api-ref
           body: |
-            Update API from [slack-api-ref](https://github.com/slack-ruby/slack-api-ref) (${{ env.CURRENT_DATE }})
+            Update API from [slack-api-ref](https://github.com/slack-ruby/slack-api-ref)
           branch: automated-api-update
           base: master
           committer: GitHub <noreply@github.com>


### PR DESCRIPTION
Removes the additional steps in the automatic API updates Action after some discussion here: https://github.com/slack-ruby/slack-ruby-client/pull/459. We'll see if this works.