### PR TITLE
Fix: fetch entire depth of commits to avoid detached HEAD.

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -1,5 +1,6 @@
 name: Update API from slack-api-ref
 on:
+  workflow_dispatch:
   schedule:
     - cron: "15 23 * * *"
 jobs:
@@ -13,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Config git to rebase
         run: git config --global pull.rebase true
       - name: Set up Ruby


### PR DESCRIPTION
Using `actions/checkout@v3` with defaults checks out a detached HEAD at `depth: 1`. When you try to `git submodule foreach git pull origin master` it will cause a conflict with the detached HEAD.

To reproduce:

```
mkdir slack-ruby-client
cd slack-ruby-client/
git init
git remote add origin https://github.com/slack-ruby/slack-ruby-client
git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +58c0f41060d1a32ec64d84a43da5c9e1547b7252:refs/remotes/origin/master
git checkout --force -B master refs/remotes/origin/master
git submodule sync --recursive
git submodule update --init --force --depth=1 --recursive # the problem is here
git submodule foreach git pull origin master
```

Here's a successful run, https://github.com/dblock/slack-ruby-client/actions/runs/4602617417 and an issue created from the change, https://github.com/dblock/slack-ruby-client/pull/2.

Needs a CHANGELOG update on top.