### PR TITLE
Fix CLI `require` to use relative path for slack ruby client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#475](https://github.com/slack-ruby-client/pulls/475): Update API from [slack-api-ref@977dad5](https://github.com/slack-ruby/slack-api-ref/commit/977dad5) - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#476](https://github.com/slack-ruby-client/pulls/476): Update API from [slack-api-ref@d0b2989](https://github.com/slack-ruby/slack-api-ref/commit/d0b2989) - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#478](https://github.com/slack-ruby-client/pulls/478): Update API from [slack-api-ref@d797055](https://github.com/slack-ruby/slack-api-ref/commit/d797055) - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
+* [#487](https://github.com/slack-ruby/slack-ruby-client/pull/487): Fix CLI `require` to use relative path for slack ruby client - [@chrisbloom7](https://github.com/chrisbloom7).
 * Your contribution here.
 
 ### 2.1.0 (2023/03/17)

--- a/bin/slack
+++ b/bin/slack
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require 'gli'
-require 'slack_ruby_client'
+require_relative '../lib/slack_ruby_client'
 
 module Slack
   module Cli

--- a/lib/slack_ruby_client.rb
+++ b/lib/slack_ruby_client.rb
@@ -1,2 +1,2 @@
 # frozen_string_literal: true
-require 'slack-ruby-client'
+require_relative 'slack-ruby-client'


### PR DESCRIPTION
Updates `bin/slack` to use a relative path to the slack ruby client to use in environments where the library isn't pre loaded (like outside of tests). Prior to this change running `bin/slack` from the command line would result in an error: 

```
<internal:/usr/local/rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- slack_ruby_client (LoadError)
        from <internal:/usr/local/rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from bin/slack:3:in `<main>'
```