### PR TITLE
Add CHANGELOG uri to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#480](https://github.com/slack-ruby-client/pulls/480): Add common message formatting utilities - [@chrisbloom7](https://github.com/chrisbloom7).
 * [#481](https://github.com/slack-ruby-client/pulls/481): Update API from [slack-api-ref@7c22d0b](https://github.com/slack-ruby/slack-api-ref/commit/7c22d0b) - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#488](https://github.com/slack-ruby-client/pulls/488): Update API from [slack-api-ref@a45def2](https://github.com/slack-ruby/slack-api-ref/commit/a45def2) - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
+* [#490](https://github.com/slack-ruby/slack-ruby-client/pull/490): Add changelog uri to gemspec - [@MatheusRich](https://github.com/MatheusRich).
 * Your contribution here.
 
 ### 2.1.0 (2023/03/17)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'gli'
   s.add_dependency 'hashie'
   s.metadata['rubygems_mfa_required'] = 'true'
+  s.metadata['changelog_uri'] = 'https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
So RubyGems can render a link for the CHANGELOG here
<img width="239" alt="image" src="https://github.com/slack-ruby/slack-ruby-client/assets/20938712/e39ac9c2-f8a1-41ec-9838-9d5b085e4134">
