### PR TITLE
Configure Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2.2.1 (Next)
 
 * Your contribution here.
-* * [#494](https://github.com/slack-ruby/slack-ruby-client/pull/494): Configure dependabot.yml to update github actions - [@olleolleolle](https://github.com/olleolleolle).
+* [#494](https://github.com/slack-ruby/slack-ruby-client/pull/494): Configure dependabot.yml to update github actions - [@olleolleolle](https://github.com/olleolleolle).
 
 ### 2.2.0 (2023/09/17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.2.1 (Next)
 
 * Your contribution here.
+* * [#494](https://github.com/slack-ruby/slack-ruby-client/pull/494): Configure dependabot.yml to update github actions - [@olleolleolle](https://github.com/olleolleolle).
 
 ### 2.2.0 (2023/09/17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2.2.1 (Next)
 
 * Your contribution here.
-* [#494](https://github.com/slack-ruby/slack-ruby-client/pull/494): Configure dependabot.yml to update github actions - [@olleolleolle](https://github.com/olleolleolle).
+* [#494](https://github.com/slack-ruby/slack-ruby-client/pull/494): Configure Dependabot to update GitHub Actions - [@olleolleolle](https://github.com/olleolleolle).
 
 ### 2.2.0 (2023/09/17)
 


### PR DESCRIPTION
I  noted there were not-latest GitHub Actions, and thought "no human being would keep those up to date".

This PR configures Dependabot to update GitHub Action versions.