### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Upload a file with [files_upload](https://api.slack.com/methods/files.upload).
 client.files_upload(
   channels: '#general',
   as_user: true,
-  file: Faraday::UploadIO.new('/path/to/avatar.jpg', 'image/jpeg'),
+  file: Faraday::Multipart::FilePart.new('/path/to/avatar.jpg', 'image/jpeg'),
   title: 'My Avatar',
   filename: 'avatar.jpg',
   initial_comment: 'Attached a selfie.'


### PR DESCRIPTION
`Faraday::UploadIO` has been [deprecated for some time](https://github.com/lostisland/faraday/blob/87e655f306454b49e459ac0a06d617cbad497fb4/CHANGELOG.md?plain=1#L45); this PR simply updates the README example to use the new class.