### PR TITLE
CI: Add Ruby 3.3 to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
           - { ruby: "3.0" }
           - { ruby: "3.1" }
           - { ruby: "3.2" }
+          - { ruby: "3.3" }
           - { ruby: ruby-head, ignore: true }
           - { ruby: jruby-head, ignore: true }
     name: test (ruby=${{ matrix.entry.ruby }}, concurrency=${{ matrix.entry.concurrency || 'none' }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.3.1 (Next)
 
+* [#516](https://github.com/slack-ruby/slack-ruby-client/pull/516): Add support for Ruby 3.3 - [@olleolleolle](https://github.com/olleolleolle).
 * Your contribution here.
 
 ### 2.3.0 (2024/01/31)


### PR DESCRIPTION
This PR adds Ruby 3.3 to the build matrix in the test suite.

Ruby 2.7 and Ruby 3.0 are both EOL, now, so their removal could be considered.