### PR TITLE
CI: Try to run bundle install just once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.entry.ruby }}
-          bundler-cache: true # 'bundle install' and cache gems
       - name: Set Concurrency
         run: |
           if [[ ! -z "${{ matrix.entry.concurrency }}" ]]; then
             echo "Setting concurrency to ${{ matrix.entry.concurrency }}."
             echo "CONCURRENCY=${{ matrix.entry.concurrency }}" >> $GITHUB_ENV
           fi
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.entry.ruby }}
+          bundler-cache: true # 'bundle install' and cache gems
       - name: Run Tests
         continue-on-error: ${{ matrix.entry.ignore || false }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.entry.ruby }}
-          bundler-cache: true
+          bundler-cache: true # 'bundle install' and cache gems
       - name: Set Concurrency
         run: |
           if [[ ! -z "${{ matrix.entry.concurrency }}" ]]; then
@@ -32,9 +32,7 @@ jobs:
         continue-on-error: ${{ matrix.entry.ignore || false }}
         env:
           RACK_ENV: test
-        run: |
-          bundle install
-          bundle exec rake
+        run: bundle exec rake
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
This PR moves the environment variable-setting Step to before the "setup Ruby" step.

The Setup Ruby step does a `bundle install`.

That means that we can remove the explicit `bundle install` later on the file.