### PR TITLE
.gitignore: Gemfile.danger.lock should not be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 .idea
 .rspec_status
 Gemfile.lock
+Gemfile.danger.lock
 pkg
 coverage


### PR DESCRIPTION
This PR adds the Danger tool's specific Gemfile to the git ignore rules.