### PR TITLE
Support basic Markdown formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.3.1 (Next)
 
-* Your contribution here.
+* [#519](https://github.com/slack-ruby/slack-ruby-client/pull/519): Support basic markdown formatting - [@nbgoodall](https://github.com/nbgoodall).
 
 ### 2.3.0 (2024/01/31)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A Ruby client for the Slack [Web](https://api.slack.com/web), [RealTime Messagin
       - [Channel ID formatting](#channel-id-formatting)
       - [User ID formatting](#user-id-formatting)
       - [URL formatting](#url-formatting)
+      - [Markdown formatting](#markdown-formatting)
     - [Parsing Messages](#parsing-messages)
       - [Unescaping message content](#unescaping-message-content)
       - [Escaping message content](#escaping-message-content)
@@ -655,6 +656,30 @@ text = 'party time'
 url = 'https://media.giphy.com/media/AcfTF7tyikWyroP0x7/giphy.gif'
 Slack::Messages::Formatting.url_link(text, url)
   # => "<https://media.giphy.com/media/AcfTF7tyikWyroP0x7/giphy.gif|party time>"
+```
+
+##### Markdown formatting
+
+Slack uses a mishmash of regular markdown formatting with its own syntax. Some features like headings aren't supported and will be left as-is, but others like bold, strikethrough, and links are converted.
+
+```ruby
+text = """
+## A heading
+**Bold text**
+~~Strikethrough text~~
+_Italic text_
+[A link](https://example.com)
+`code`
+"""
+Slack::Messages::Formatting.markdown(text)
+  # => """
+  # ## A heading
+  # *Bold text*
+  # ~Strikethrough text~
+  # _Italic text_
+  # <https://example.com|A link>
+  # `code`
+  # """
 ```
 
 #### Parsing Messages

--- a/lib/slack/messages/formatting.rb
+++ b/lib/slack/messages/formatting.rb
@@ -68,6 +68,23 @@ module Slack
         def url_link(text, url)
           "<#{url}|#{text}>"
         end
+
+        #
+        # Converts text from basic markdown into Slack's mishmash
+        # @see https://api.slack.com/reference/surfaces/formatting#basic-formatting
+        #
+        def markdown(text)
+          # convert bold
+          slack_md = text.gsub(/\*\*(.*?)\*\*/, '*\1*')
+
+          # convert strikethrough
+          slack_md = text.gsub(/~~(.*?)~~/, '~\1~')
+
+          # convert links
+          slack_md = slack_md.gsub(/\[(.*?)\]\((.*?)\)/, '<\2|\1>')
+
+          slack_md
+        end
       end
     end
   end

--- a/lib/slack/messages/formatting.rb
+++ b/lib/slack/messages/formatting.rb
@@ -81,9 +81,7 @@ module Slack
           slack_md = slack_md.gsub(/~~(.*?)~~/, '~\1~')
 
           # convert links
-          slack_md = slack_md.gsub(/\[(.*?)\]\((.*?)\)/, '<\2|\1>')
-
-          slack_md
+          slack_md.gsub(/\[(.*?)\]\((.*?)\)/, '<\2|\1>')
         end
       end
     end

--- a/lib/slack/messages/formatting.rb
+++ b/lib/slack/messages/formatting.rb
@@ -78,7 +78,7 @@ module Slack
           slack_md = text.gsub(/\*\*(.*?)\*\*/, '*\1*')
 
           # convert strikethrough
-          slack_md = text.gsub(/~~(.*?)~~/, '~\1~')
+          slack_md = slack_md.gsub(/~~(.*?)~~/, '~\1~')
 
           # convert links
           slack_md = slack_md.gsub(/\[(.*?)\]\((.*?)\)/, '<\2|\1>')

--- a/spec/slack/messages/formatting_spec.rb
+++ b/spec/slack/messages/formatting_spec.rb
@@ -124,19 +124,19 @@ describe Slack::Messages::Formatting do
 
   context '#markdown' do
     it 'formats markdown bold' do
-      expect(formatting.markdown("**Le bold**")).to eq "*Le bold*"
+      expect(formatting.markdown('**Le bold**')).to eq '*Le bold*'
     end
 
     it 'formats markdown strikethrough' do
-      expect(formatting.markdown("~~Le strikethrough~~")).to eq "~Le strikethrough~"
+      expect(formatting.markdown('~~Le strikethrough~~')).to eq '~Le strikethrough~'
     end
 
     it 'formats markdown links' do
-      expect(formatting.markdown("[Le link](https://theuselessweb.site)")).to eq "<https://theuselessweb.site|Le link>"
+      expect(formatting.markdown('[Le link](https://theuselessweb.site)')).to eq '<https://theuselessweb.site|Le link>'
     end
 
     it "doesn't format other markdown" do
-      expect(formatting.markdown("## A heading\n_Italics_\n`code`")).to eq "## A heading\n_Italics_\n`code`"
+      expect(formatting.markdown('## A heading\n_Italics_\n`code`')).to eq '## A heading\n_Italics_\n`code`'
     end
   end
 end

--- a/spec/slack/messages/formatting_spec.rb
+++ b/spec/slack/messages/formatting_spec.rb
@@ -121,4 +121,22 @@ describe Slack::Messages::Formatting do
       expect(formatting.url_link(text, url)).to eq "<#{url}|#{text}>"
     end
   end
+
+  context '#markdown' do
+    it 'formats markdown bold' do
+      expect(formatting.markdown("**Le bold**")).to eq "*Le bold*"
+    end
+
+    it 'formats markdown strikethrough' do
+      expect(formatting.markdown("~~Le strikethrough~~")).to eq "~Le strikethrough~"
+    end
+
+    it 'formats markdown links' do
+      expect(formatting.markdown("[Le link](https://theuselessweb.site)")).to eq "<https://theuselessweb.site|Le link>"
+    end
+
+    it "doesn't format other markdown" do
+      expect(formatting.markdown("## A heading\n_Italics_\n`code`")).to eq "## A heading\n_Italics_\n`code`"
+    end
+  end
 end


### PR DESCRIPTION
This PR adds basic support for Slack's markdown formatting, specifically **bold**, ~~strikethrough~~ and [links](https://example.com). Non-supported features like headings and tables are left as-is.

Closes #249.