### PR TITLE
Fix: support arg groups with just 1 item.

### DIFF
--- a/lib/slack/web/api/templates/method.erb
+++ b/lib/slack/web/api/templates/method.erb
@@ -38,6 +38,7 @@ module Slack
             raise ArgumentError, 'Required arguments :<%= arg_name %> missing' if options[:<%= arg_name %>].nil?
 <% end %>
 <% data['arg_groups']&.each do |arg_group| %>
+  <% next if arg_group['args'].size <= 1 %>
 <% arg_string = arg_group['args'].map { |arg_name| ":#{arg_name}" }.join(', ') %>
 <% if arg_group['mutually_exclusive'] %>
             raise ArgumentError, 'Exactly one of <%= arg_string %> is required' unless <%= arg_group['args'].map { |arg_name| "options[:#{arg_name}].nil?" }.join(' ^ ') %>

--- a/lib/slack/web/api/templates/method_spec.erb
+++ b/lib/slack/web/api/templates/method_spec.erb
@@ -7,7 +7,7 @@ RSpec.describe Slack::Web::Api::Endpoints::<%= group.gsub(".", "_").camelize %> 
   let(:client) { Slack::Web::Client.new }
 <% names.sort.each_with_index do |(name, data), index| %>
 <% next if data['mixin'] %>
-<% group_required_params = data['arg_groups']&.map { |grp| grp['args'].first } || [] %>
+<% group_required_params = data['arg_groups']&.map { |grp| grp['args'].first if grp['args'].size > 1 } || [] %>
 <% required_params = data['args'].select{ |k, v| v['required'] || group_required_params.include?(k) } %>
 <% json_params = data['args'].map { |arg_name, arg_v| arg_name if arg_v['format'] == 'json' }.compact %>
 <% next if (required_params.none? || custom_spec_exists) && json_params.none? && data['arg_groups'].nil? %>
@@ -23,6 +23,7 @@ RSpec.describe Slack::Web::Api::Endpoints::<%= group.gsub(".", "_").camelize %> 
 <% end %>
 <% end %>
 <% data['arg_groups']&.each do |arg_group| %>
+    <% next if arg_group['args'].size <= 1 %>
     it 'requires one of <%= arg_group['args'].join(', ') %>' do
 <% params_except_required = example_params.reject { |name, _| arg_group['args'].include?(name)  }.map { |name, val| "#{name}: %q[#{val}]" }.join(', ') %>
 <% error_message = arg_group['mutually_exclusive'] ? 'Exactly' : 'At least' %>


### PR DESCRIPTION
Auto updates started failing because an arg group has one single item in https://github.com/slack-ruby/slack-api-ref/blob/3ec3c101d99cb5ab8af3694e57d883f04cfd5e2f/methods/functions/functions.distributions.permissions.set.json#L39. 

https://github.com/slack-ruby/slack-ruby-client/actions/runs/9915284555/job/27395881714?pr=509