### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.4.1 (Next)
 
+* [#525](https://github.com/slack-ruby/slack-ruby-client/pull/525): Exclude spec files from gem package - [@amatsuda](https://github.com/amatsuda).
 * Your contribution here.
 
 ### 2.4.0 (2024/07/14)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.7'
   s.required_rubygems_version = '>= 1.3.6'
-  s.files = `git ls-files`.split("\n")
+  s.files = `git ls-files`.split("\n").grep_v(%r{^spec/})
   s.require_paths = ['lib']
   s.homepage = 'http://github.com/slack-ruby/slack-ruby-client'
   s.licenses = ['MIT']


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 355840 bytes
after:  293376 bytes
```