### PR TITLE
Don't treat asterisks in list items as italic in Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#525](https://github.com/slack-ruby/slack-ruby-client/pull/525): Exclude spec files from gem package - [@amatsuda](https://github.com/amatsuda).
 * [#527](https://github.com/slack-ruby/slack-ruby-client/pull/527): Explicitly require `racc` and `ostruct` - [@dblock](https://github.com/dblock).
+* [#528](https://github.com/slack-ruby/slack-ruby-client/pull/528): Don't treat asterisks in list items as italic in markdown - [@rspeicher](https://github.com/rspeicher).
 * Your contribution here.
 
 ### 2.4.0 (2024/07/14)

--- a/lib/slack/messages/formatting.rb
+++ b/lib/slack/messages/formatting.rb
@@ -75,7 +75,7 @@ module Slack
         #
         def markdown(text)
           text
-            .gsub(/(?<!\*)\*([^*]+)\*(?!\*)/, '_\1_') # italic
+            .gsub(/(?<!\*)\*([^*\n]+)\*(?!\*)/, '_\1_') # italic
             .gsub(/\*\*\*(.*?)\*\*\*/, '*_\1_*') # bold & italic
             .gsub(/\*\*(.*?)\*\*/, '*\1*') # bold
             .gsub(/~~(.*?)~~/, '~\1~') # strikethrough

--- a/spec/slack/messages/formatting_spec.rb
+++ b/spec/slack/messages/formatting_spec.rb
@@ -149,6 +149,18 @@ describe Slack::Messages::Formatting do
       )
     end
 
+    it "doesn't treat list items as text formatting" do
+      msg = <<~MSG
+        Une liste:
+
+        * Article 1
+        * Article 2
+        * Article 3
+      MSG
+
+      expect(formatting.markdown(msg)).to eq msg
+    end
+
     it "doesn't format other markdown" do
       expect(formatting.markdown('## A heading\n_Italics_\n`code`')).to eq '## A heading\n_Italics_\n`code`'
     end


### PR DESCRIPTION
Fixes an issue where asterisks used for list items were converted to underscores.

Before:

```
  1) Slack::Messages::Formatting#markdown doesn't treat list items as text formatting
     Failure/Error: expect(formatting.markdown(msg)).to eq msg
     
       expected: "Une liste:\n\n* Article 1\n* Article 2\n* Article 3\n"
            got: "Une liste:\n\n_ Article 1\n_ Article 2\n* Article 3\n"
     
       (compared using ==)
     
       Diff:
       @@ -1,6 +1,6 @@
        Une liste:
        
       -* Article 1
       -* Article 2
       +_ Article 1
       +_ Article 2
        * Article 3
       
     # ./spec/slack/messages/formatting_spec.rb:161:in `block (3 levels) in <top (required)>'
```

Introduced in https://github.com/slack-ruby/slack-ruby-client/pull/520.