### PR TITLE
Specify dependency on logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#525](https://github.com/slack-ruby/slack-ruby-client/pull/525): Exclude spec files from gem package - [@amatsuda](https://github.com/amatsuda).
 * [#527](https://github.com/slack-ruby/slack-ruby-client/pull/527): Explicitly require `racc` and `ostruct` - [@dblock](https://github.com/dblock).
 * [#528](https://github.com/slack-ruby/slack-ruby-client/pull/528): Don't treat asterisks in list items as italic in markdown - [@rspeicher](https://github.com/rspeicher).
+* [#530](https://github.com/slack-ruby/slack-ruby-client/pull/530): Specify dependency on logger - [@rwstauner](https://github.com/rwstauner).
 * Your contribution here.
 
 ### 2.4.0 (2024/07/14)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday-multipart'
   s.add_dependency 'gli'
   s.add_dependency 'hashie'
+  s.add_dependency 'logger'
   s.metadata['rubygems_mfa_required'] = 'true'
   s.metadata['changelog_uri'] = 'https://github.com/slack-ruby/slack-ruby-client/blob/master/CHANGELOG.md'
 end


### PR DESCRIPTION
It's moving from the stdlib to a gem in ruby 3.5:
https://github.com/ruby/ruby/commit/cda268d8e99170f73c9c0c7dd2dbe9494ba89abb
