### PR TITLE
fix: `files_upload_v2` usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ This library provides a helper method `files_upload_v2` that wraps the three sep
 client.files_upload_v2(
   # required options
   filename: 'results.pdf', # this is used for the file title, unless a :title option is provided
-  contents: File.read('/users/me/results.pdf'), # the string contents of the file
+  content: File.read('/users/me/results.pdf'), # the string contents of the file
   
   # optional options
   channels: ['C000000', 'C000001'], # channel IDs to share the file in (:channel_id, :channel, or :channels are all supported)


### PR DESCRIPTION
Fixed according to the current API

https://github.com/slack-ruby/slack-ruby-client/blob/b05610b0d70bed4ecb079260892478077737d313/lib/slack/web/api/helpers/files.rb#L34-L37