### PR TITLE
More efficient name-to-id translation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
           parallel: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: run-${{ matrix.entry.ruby }}${{ matrix.entry.concurrency && '-'}}${{ matrix.entry.concurrency }}
+          allow-empty: ${{ matrix.entry.ignore || false }}
 
   finish:
     name: coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [#549](https://github.com/slack-ruby/slack-ruby-client/pull/549): Add group ID formatting support for message mentions - [@n0h0](https://github.com/n0h0).
 * [#553](https://github.com/slack-ruby/slack-ruby-client/pull/553): Use `secure_compare` during signature verification - [@hieuk09](https://github.com/hieuk09).
-* [#555](https://github.com/slack-ruby/slack-ruby-client/pull/555): Make page size in resolving conversation IDs configurable - [@eizengan](https://github.com/eizengan).
+* [#555](https://github.com/slack-ruby/slack-ruby-client/pull/555): Make page size in resolving IDs configurable - [@eizengan](https://github.com/eizengan).
 * Your contribution here.
 
 ### 2.5.2 (2025/02/19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#549](https://github.com/slack-ruby/slack-ruby-client/pull/549): Add group ID formatting support for message mentions - [@n0h0](https://github.com/n0h0).
 * [#553](https://github.com/slack-ruby/slack-ruby-client/pull/553): Use `secure_compare` during signature verification - [@hieuk09](https://github.com/hieuk09).
+* [#555](https://github.com/slack-ruby/slack-ruby-client/pull/555): Make page size in resolving conversation IDs configurable - [@eizengan](https://github.com/eizengan).
 * Your contribution here.
 
 ### 2.5.2 (2025/02/19)

--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ timeout                      | Optional open/read timeout in seconds.
 open_timeout                 | Optional connection open timeout in seconds.
 default_page_size            | Optional page size for paginated requests, default is _100_.
 conversations_id_page_size   | Optional page size for conversations_list requests made when calculating conversation id from a conversation name, default is _equal to default_page_size_.
+users_id_page_size           | Optional page size for users_list requests made when calculating user id from a user name, default is _equal to default_page_size_.
 default_max_retries          | Optional number of retries for paginated requests, default is _100_.
 adapter                      | Optional HTTP adapter to use, defaults to `Faraday.default_adapter`.
 

--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ logger                       | Optional `Logger` instance that logs HTTP request
 timeout                      | Optional open/read timeout in seconds.
 open_timeout                 | Optional connection open timeout in seconds.
 default_page_size            | Optional page size for paginated requests, default is _100_.
-conversations_id_page_size   | Optional page size for conversations_list requests made when calculating conversation id from a conversation name, default is _equal to default_page_size_.
-users_id_page_size           | Optional page size for users_list requests made when calculating user id from a user name, default is _equal to default_page_size_.
+conversations_id_page_size   | Optional page size for conversations_list requests made when calculating conversation id from a conversation name, default is _nil_, which will use the default_page_size.
+users_id_page_size           | Optional page size for users_list requests made when calculating user id from a user name, default is _nil_, which will use the default_page_size.
 default_max_retries          | Optional number of retries for paginated requests, default is _100_.
 adapter                      | Optional HTTP adapter to use, defaults to `Faraday.default_adapter`.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ client.files_upload_v2(
   # required options
   filename: 'results.pdf', # this is used for the file title, unless a :title option is provided
   content: File.read('/users/me/results.pdf'), # the string contents of the file
-  
+
   # optional options
   channels: ['C000000', 'C000001'], # channel IDs to share the file in (:channel_id, :channel, or :channels are all supported)
   initial_comment: 'Sharing the Q1 results :tada:', # the message that is included with the file share thread
@@ -281,20 +281,21 @@ client = Slack::Web::Client.new(user_agent: 'Slack Ruby Client/1.0')
 
 The following settings are supported.
 
-setting             | description
---------------------|-------------------------------------------------------------------------------------------------
-token               | Slack API token.
-user_agent          | User-agent, defaults to _Slack Ruby Client/version_.
-proxy               | Optional HTTP proxy.
-ca_path             | Optional SSL certificates path.
-ca_file             | Optional SSL certificates file.
-endpoint            | Slack endpoint, default is _https://slack.com/api_.
-logger              | Optional `Logger` instance that logs HTTP requests.
-timeout             | Optional open/read timeout in seconds.
-open_timeout        | Optional connection open timeout in seconds.
-default_page_size   | Optional page size for paginated requests, default is _100_.
-default_max_retries | Optional number of retries for paginated requests, default is _100_.
-adapter             | Optional HTTP adapter to use, defaults to `Faraday.default_adapter`.
+setting                      | description
+-----------------------------|-------------------------------------------------------------------------------------------------
+token                        | Slack API token.
+user_agent                   | User-agent, defaults to _Slack Ruby Client/version_.
+proxy                        | Optional HTTP proxy.
+ca_path                      | Optional SSL certificates path.
+ca_file                      | Optional SSL certificates file.
+endpoint                     | Slack endpoint, default is _https://slack.com/api_.
+logger                       | Optional `Logger` instance that logs HTTP requests.
+timeout                      | Optional open/read timeout in seconds.
+open_timeout                 | Optional connection open timeout in seconds.
+default_page_size            | Optional page size for paginated requests, default is _100_.
+conversations_id_page_size   | Optional page size for conversations_list requests made when calculating conversation id from a conversation name, default is _equal to default_page_size_.
+default_max_retries          | Optional number of retries for paginated requests, default is _100_.
+adapter                      | Optional HTTP adapter to use, defaults to `Faraday.default_adapter`.
 
 You can also pass request options, including `timeout` and `open_timeout` into individual calls.
 

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -12,8 +12,12 @@ module Slack
           #
           # @option options [channel] :channel
           #   Channel to get ID for, prefixed with #.
+          # @option options [integer] :limit
+          #   The page size used for conversations_list calls required to find the channel's ID
           def conversations_id(options = {})
             name = options[:channel]
+            limit = options.fetch(:limit, conversations_id_page_size)
+
             raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 
             id_for(
@@ -23,7 +27,7 @@ module Slack
               :conversations_list,
               :channels,
               'channel_not_found',
-              enum_method_options: { limit: conversations_id_page_size }
+              enum_method_options: { limit: limit }
             )
           end
         end

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -12,22 +12,21 @@ module Slack
           #
           # @option options [channel] :channel
           #   Channel to get ID for, prefixed with #.
-          # @option options [integer] :limit
+          # @option options [integer] :id_limit
           #   The page size used for conversations_list calls required to find the channel's ID
           def conversations_id(options = {})
             name = options[:channel]
-            limit = options.fetch(:limit, conversations_id_page_size)
+            limit = options.fetch(:id_limit, conversations_id_page_size)
 
             raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 
             id_for(
-              :channel,
-              name,
-              '#',
-              :conversations_list,
-              :channels,
-              'channel_not_found',
-              enum_method_options: { limit: limit }
+              key: :channel,
+              name: name,
+              prefix: '#',
+              enum_method: :conversations_list,
+              list_method: :channels,
+              options: { limit: limit }
             )
           end
         end

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -26,7 +26,7 @@ module Slack
               prefix: '#',
               enum_method: :conversations_list,
               list_method: :channels,
-              options: { limit: limit }
+              options: { limit: limit }.compact
             )
           end
         end

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -16,7 +16,7 @@ module Slack
           #   The page size used for conversations_list calls required to find the channel's ID
           def conversations_id(options = {})
             name = options[:channel]
-            limit = options.fetch(:id_limit, conversations_id_page_size)
+            limit = options.fetch(:id_limit, Slack::Web.config.conversations_id_page_size)
 
             raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -16,7 +16,15 @@ module Slack
             name = options[:channel]
             raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 
-            id_for :channel, name, '#', :conversations_list, :channels, 'channel_not_found'
+            id_for(
+              :channel,
+              name,
+              '#',
+              :conversations_list,
+              :channels,
+              'channel_not_found',
+              enum_method_options: { limit: conversations_id_page_size }
+            )
           end
         end
       end

--- a/lib/slack/web/api/mixins/ids.id.rb
+++ b/lib/slack/web/api/mixins/ids.id.rb
@@ -6,15 +6,16 @@ module Slack
         module Ids
           private
 
-          def id_for(key, name, prefix, enum_method, list_method, not_found_error, enum_method_options: {}) # rubocop:disable Metrics/ParameterLists
+          def id_for(key:, name:, prefix:, enum_method:, list_method:, options: {})
             return { 'ok' => true, key.to_s => { 'id' => name } } unless name[0] == prefix
 
-            public_send(enum_method, **enum_method_options) do |list|
+            public_send(enum_method, **options) do |list|
               list.public_send(list_method).each do |li|
                 return Slack::Messages::Message.new('ok' => true, key.to_s => { 'id' => li.id }) if li.name == name[1..-1]
               end
             end
 
+            not_found_error = "#{key}_not_found"
             raise Slack::Web::Api::Errors::SlackError, not_found_error
           end
         end

--- a/lib/slack/web/api/mixins/ids.id.rb
+++ b/lib/slack/web/api/mixins/ids.id.rb
@@ -6,10 +6,10 @@ module Slack
         module Ids
           private
 
-          def id_for(key, name, prefix, enum_method, list_method, not_found_error)
+          def id_for(key, name, prefix, enum_method, list_method, not_found_error, enum_method_options: {}) # rubocop:disable Metrics/ParameterLists
             return { 'ok' => true, key.to_s => { 'id' => name } } unless name[0] == prefix
 
-            public_send enum_method do |list|
+            public_send(enum_method, **enum_method_options) do |list|
               list.public_send(list_method).each do |li|
                 return Slack::Messages::Message.new('ok' => true, key.to_s => { 'id' => li.id }) if li.name == name[1..-1]
               end

--- a/lib/slack/web/api/mixins/ids.id.rb
+++ b/lib/slack/web/api/mixins/ids.id.rb
@@ -15,8 +15,7 @@ module Slack
               end
             end
 
-            not_found_error = "#{key}_not_found"
-            raise Slack::Web::Api::Errors::SlackError, not_found_error
+            raise Slack::Web::Api::Errors::SlackError, "#{key}_not_found"
           end
         end
       end

--- a/lib/slack/web/api/mixins/users.id.rb
+++ b/lib/slack/web/api/mixins/users.id.rb
@@ -16,7 +16,7 @@ module Slack
           #   The page size used for users_list calls required to find the user's ID
           def users_id(options = {})
             name = options[:user]
-            limit = options.fetch(:id_limit, users_id_page_size)
+            limit = options.fetch(:id_limit, Slack::Web.config.users_id_page_size)
 
             raise ArgumentError, 'Required arguments :user missing' if name.nil?
 

--- a/lib/slack/web/api/mixins/users.id.rb
+++ b/lib/slack/web/api/mixins/users.id.rb
@@ -26,7 +26,7 @@ module Slack
               prefix: '@',
               enum_method: :users_list,
               list_method: :members,
-              options: { limit: limit }
+              options: { limit: limit }.compact
             )
           end
         end

--- a/lib/slack/web/api/mixins/users.id.rb
+++ b/lib/slack/web/api/mixins/users.id.rb
@@ -12,11 +12,23 @@ module Slack
           #
           # @option options [user] :user
           #   User to get ID for, prefixed with '@'.
+          # @option options [integer] :limit
+          #   The page size used for users_list calls required to find the user's ID
           def users_id(options = {})
             name = options[:user]
+            limit = options.fetch(:limit, users_id_page_size)
+
             raise ArgumentError, 'Required arguments :user missing' if name.nil?
 
-            id_for :user, name, '@', :users_list, :members, 'user_not_found'
+            id_for(
+              :user,
+              name,
+              '@',
+              :users_list,
+              :members,
+              'user_not_found',
+              enum_method_options: { limit: limit }
+            )
           end
         end
       end

--- a/lib/slack/web/api/mixins/users.id.rb
+++ b/lib/slack/web/api/mixins/users.id.rb
@@ -12,22 +12,21 @@ module Slack
           #
           # @option options [user] :user
           #   User to get ID for, prefixed with '@'.
-          # @option options [integer] :limit
+          # @option options [integer] :id_limit
           #   The page size used for users_list calls required to find the user's ID
           def users_id(options = {})
             name = options[:user]
-            limit = options.fetch(:limit, users_id_page_size)
+            limit = options.fetch(:id_limit, users_id_page_size)
 
             raise ArgumentError, 'Required arguments :user missing' if name.nil?
 
             id_for(
-              :user,
-              name,
-              '@',
-              :users_list,
-              :members,
-              'user_not_found',
-              enum_method_options: { limit: limit }
+              key: :user,
+              name: name,
+              prefix: '@',
+              enum_method: :users_list,
+              list_method: :members,
+              options: { limit: limit }
             )
           end
         end

--- a/lib/slack/web/config.rb
+++ b/lib/slack/web/config.rb
@@ -34,8 +34,8 @@ module Slack
         self.timeout = nil
         self.open_timeout = nil
         self.default_page_size = 100
-        self.conversations_id_page_size = default_page_size
-        self.users_id_page_size = default_page_size
+        self.conversations_id_page_size = nil
+        self.users_id_page_size = nil
         self.default_max_retries = 100
         self.adapter = ::Faraday.default_adapter
       end

--- a/lib/slack/web/config.rb
+++ b/lib/slack/web/config.rb
@@ -15,6 +15,7 @@ module Slack
         timeout
         open_timeout
         default_page_size
+        conversations_id_page_size
         default_max_retries
         adapter
       ].freeze
@@ -32,6 +33,7 @@ module Slack
         self.timeout = nil
         self.open_timeout = nil
         self.default_page_size = 100
+        self.conversations_id_page_size = default_page_size
         self.default_max_retries = 100
         self.adapter = ::Faraday.default_adapter
       end

--- a/lib/slack/web/config.rb
+++ b/lib/slack/web/config.rb
@@ -16,6 +16,7 @@ module Slack
         open_timeout
         default_page_size
         conversations_id_page_size
+        users_id_page_size
         default_max_retries
         adapter
       ].freeze
@@ -34,6 +35,7 @@ module Slack
         self.open_timeout = nil
         self.default_page_size = 100
         self.conversations_id_page_size = default_page_size
+        self.users_id_page_size = default_page_size
         self.default_max_retries = 100
         self.adapter = ::Faraday.default_adapter
       end

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
   end
 
   before do
-    allow(conversations).to receive(:conversations_id_page_size) { Slack::Web.config.conversations_id_page_size }
     allow(conversations).to receive(:conversations_list).and_yield(
       Slack::Messages::Message.new(
         'channels' => [{

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
       )
     end
 
+    it 'forwards a provided limit to the underlying conversations_list calls' do
+      expect(conversations).to receive(:conversations_list).with(limit: 1234)
+      conversations.conversations_id(channel: '#general', limit: 1234)
+    end
+
     it 'fails with an exception' do
       expect { conversations.conversations_id(channel: '#invalid') }.to(
         raise_error(Slack::Web::Api::Errors::SlackError, 'channel_not_found')

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
     end
 
     it 'translates a channel that starts with a #' do
-      expect(conversations).to receive(:conversations_list).with(limit: 100)
+      expect(conversations).to receive(:conversations_list)
       expect(conversations.conversations_id(channel: '#general')).to(
         eq('ok' => true, 'channel' => { 'id' => 'CDEADBEEF' })
       )

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
   end
 
   before do
+    allow(conversations).to receive(:conversations_id_page_size).and_return(100)
     allow(conversations).to receive(:conversations_list).and_yield(
       Slack::Messages::Message.new(
         'channels' => [{

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
   end
 
   before do
-    allow(conversations).to receive(:conversations_id_page_size).and_return(100)
+    allow(conversations).to receive(:conversations_id_page_size) { Slack::Web.config.conversations_id_page_size }
     allow(conversations).to receive(:conversations_list).and_yield(
       Slack::Messages::Message.new(
         'channels' => [{
@@ -32,6 +32,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
     end
 
     it 'translates a channel that starts with a #' do
+      expect(conversations).to receive(:conversations_list).with(limit: 100)
       expect(conversations.conversations_id(channel: '#general')).to(
         eq('ok' => true, 'channel' => { 'id' => 'CDEADBEEF' })
       )
@@ -46,6 +47,24 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
       expect { conversations.conversations_id(channel: '#invalid') }.to(
         raise_error(Slack::Web::Api::Errors::SlackError, 'channel_not_found')
       )
+    end
+
+    context 'when a non-default conversations_id page size has been configured' do
+      before { Slack::Web.config.conversations_id_page_size = 500 }
+
+      after { Slack::Web.config.reset }
+
+      it 'translates a channel that starts with a #' do
+        expect(conversations).to receive(:conversations_list).with(limit: 500)
+        expect(conversations.conversations_id(channel: '#general')).to(
+          eq('ok' => true, 'channel' => { 'id' => 'CDEADBEEF' })
+        )
+      end
+
+      it 'forwards a provided limit to the underlying conversations_list calls' do
+        expect(conversations).to receive(:conversations_list).with(limit: 1234)
+        conversations.conversations_id(channel: '#general', limit: 1234)
+      end
     end
   end
 end

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
 
     it 'forwards a provided limit to the underlying conversations_list calls' do
       expect(conversations).to receive(:conversations_list).with(limit: 1234)
-      conversations.conversations_id(channel: '#general', limit: 1234)
+      conversations.conversations_id(channel: '#general', id_limit: 1234)
     end
 
     it 'fails with an exception' do
@@ -63,7 +63,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
 
       it 'forwards a provided limit to the underlying conversations_list calls' do
         expect(conversations).to receive(:conversations_list).with(limit: 1234)
-        conversations.conversations_id(channel: '#general', limit: 1234)
+        conversations.conversations_id(channel: '#general', id_limit: 1234)
       end
     end
   end

--- a/spec/slack/web/api/mixins/users_spec.rb
+++ b/spec/slack/web/api/mixins/users_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
   end
 
   before do
-    allow(users).to receive(:users_id_page_size) { Slack::Web.config.users_id_page_size }
     allow(users).to receive(:users_list).and_yield(
       Slack::Messages::Message.new(
         'members' => [{

--- a/spec/slack/web/api/mixins/users_spec.rb
+++ b/spec/slack/web/api/mixins/users_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
 
     it 'forwards a provided limit to the underlying users_list calls' do
       expect(users).to receive(:users_list).with(limit: 1234)
-      users.users_id(user: '@aws', limit: 1234)
+      users.users_id(user: '@aws', id_limit: 1234)
     end
 
     it 'fails with an exception' do
@@ -58,7 +58,7 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
 
       it 'forwards a provided limit to the underlying users_list calls' do
         expect(users).to receive(:users_list).with(limit: 1234)
-        users.users_id(user: '@aws', limit: 1234)
+        users.users_id(user: '@aws', id_limit: 1234)
       end
     end
   end

--- a/spec/slack/web/api/mixins/users_spec.rb
+++ b/spec/slack/web/api/mixins/users_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
   end
 
   before do
+    allow(users).to receive(:users_id_page_size).and_return(100)
     allow(users).to receive(:users_list).and_yield(
       Slack::Messages::Message.new(
         'members' => [{
@@ -31,6 +32,11 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
 
     it 'translates a user that starts with a @' do
       expect(users.users_id(user: '@aws')).to eq('ok' => true, 'user' => { 'id' => 'UDEADBEEF' })
+    end
+
+    it 'forwards a provided limit to the underlying users_list calls' do
+      expect(users).to receive(:users_list).with(limit: 1234)
+      users.users_id(user: '@aws', limit: 1234)
     end
 
     it 'fails with an exception' do

--- a/spec/slack/web/api/mixins/users_spec.rb
+++ b/spec/slack/web/api/mixins/users_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
     end
 
     it 'translates a user that starts with a @' do
-      expect(users).to receive(:users_list).with(limit: 100)
+      expect(users).to receive(:users_list)
       expect(users.users_id(user: '@aws')).to eq('ok' => true, 'user' => { 'id' => 'UDEADBEEF' })
     end
 


### PR DESCRIPTION
The `conversations_id` method paginates with default options over [conversations.list](https://api.slack.com/methods/conversations.list) responses to find a conversation with a particular name. The `conversations.list` endpoint has a [Tier 2 rate limit](https://api.slack.com/apis/rate-limits#tier_t2), which - when combined with the low default page size - can cause just a single call in a workspace with 2000+ channels to result in rate limiting. This change enables use of non-default page sizes within `conversations_id` (and `id_for`, more generally), thus reducing the risk of rate limiting within such workspaces.