### PR TITLE
Require Faraday 2.0.1 or greater (#554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 2.6.1 (Next)
 
+* [#554](https://github.com/slack-ruby/slack-ruby-client/pull/557): Require Faraday >= 2.0.1 - [@anrichvs](https://github.com/AnrichVS).
 * Your contribution here.
 
 ### 2.6.0 (2025/05/24)

--- a/slack-ruby-client.gemspec
+++ b/slack-ruby-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/slack-ruby/slack-ruby-client'
   s.licenses = ['MIT']
   s.summary = 'Slack Web and RealTime API client.'
-  s.add_dependency 'faraday', '>= 2.0'
+  s.add_dependency 'faraday', '>= 2.0.1'
   s.add_dependency 'faraday-mashify'
   s.add_dependency 'faraday-multipart'
   s.add_dependency 'gli'


### PR DESCRIPTION
Faraday version 2.0.0 had a bug that resulted in no default adapter being instantiated. This was fixed in version 2.0.1 - https://github.com/lostisland/faraday/commit/5f88f8ff85c574e30e2cea46324b90c3ffa7ff53