### PR TITLE
Enable name-to-id translation for private channels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.entry.ruby }}
           bundler-cache: true # 'bundle install' and cache gems
+        continue-on-error: ${{ matrix.entry.ignore || false }}
       - name: Run Tests
         continue-on-error: ${{ matrix.entry.ignore || false }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.6.1 (Next)
 
 * [#554](https://github.com/slack-ruby/slack-ruby-client/pull/557): Require Faraday >= 2.0.1 - [@anrichvs](https://github.com/AnrichVS).
+* [#559](https://github.com/slack-ruby/slack-ruby-client/pull/559): Enable name-to-id translation of non-public channels - [@eizengan](https://github.com/eizengan).
 * Your contribution here.
 
 ### 2.6.0 (2025/05/24)

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -14,9 +14,13 @@ module Slack
           #   Channel to get ID for, prefixed with #.
           # @option options [integer] :id_limit
           #   The page size used for conversations_list calls required to find the channel's ID
+          # @option options [string] :id_types
+          #   The types of conversations to use when searching for the ID. A comma-separated list
+          #   containing one or more of public_channel, private_channel, mpim, im
           def conversations_id(options = {})
             name = options[:channel]
             limit = options.fetch(:id_limit, Slack::Web.config.conversations_id_page_size)
+            types = options.fetch(:id_types, nil)
 
             raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 
@@ -26,7 +30,7 @@ module Slack
               prefix: '#',
               enum_method: :conversations_list,
               list_method: :channels,
-              options: { limit: limit }.compact
+              options: { limit: limit, types: types }.compact
             )
           end
         end

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -37,9 +37,14 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
       )
     end
 
-    it 'forwards a provided limit to the underlying conversations_list calls' do
+    it 'forwards the provided limit to the underlying conversations_list calls' do
       expect(conversations).to receive(:conversations_list).with(limit: 1234)
       conversations.conversations_id(channel: '#general', id_limit: 1234)
+    end
+
+    it 'forwards a provided types to the underlying conversations_list calls' do
+      expect(conversations).to receive(:conversations_list).with(types: 'public_channel,private_channel')
+      conversations.conversations_id(channel: '#general', id_types: 'public_channel,private_channel')
     end
 
     it 'fails with an exception' do


### PR DESCRIPTION
Ran into another hitch with name-to-id translation: the gem is only capable of translating public channels.

This first pass does the minimum amount of work to make the feature happen. It has an obvious flaw, however, in that the continued addition of [new arguments](https://api.slack.com/methods/conversations.list#args) feels untenable (e.g. team_id or exclude_archived). Perhaps this is the last argument we need/want, and the first-pass solution is fine - or perhaps not. It's a good starting point for conversation, regardless. We can refine once I hear your thoughts.