### PR TITLE
*_id methods may be supplied with all sensible options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#554](https://github.com/slack-ruby/slack-ruby-client/pull/557): Require Faraday >= 2.0.1 - [@anrichvs](https://github.com/AnrichVS).
 * [#559](https://github.com/slack-ruby/slack-ruby-client/pull/559): Enable name-to-id translation of non-public channels - [@eizengan](https://github.com/eizengan).
+* [#560](https://github.com/slack-ruby/slack-ruby-client/pull/560): Name-to-id translation can supply all sensible list options - [@eizengan](https://github.com/eizengan).
 * Your contribution here.
 
 ### 2.6.0 (2025/05/24)

--- a/lib/slack/web/api/mixins/conversations.id.rb
+++ b/lib/slack/web/api/mixins/conversations.id.rb
@@ -12,6 +12,11 @@ module Slack
           #
           # @option options [channel] :channel
           #   Channel to get ID for, prefixed with #.
+          # @option options [string] :team_id
+          #   The team id to search for channels in, required if token belongs to org-wide app.
+          #   This field will be ignored if the API call is sent using a workspace-level token.
+          # @option options [boolean] :id_exclude_archived
+          #   Set to true to exclude archived channels from the search
           # @option options [integer] :id_limit
           #   The page size used for conversations_list calls required to find the channel's ID
           # @option options [string] :id_types
@@ -19,9 +24,6 @@ module Slack
           #   containing one or more of public_channel, private_channel, mpim, im
           def conversations_id(options = {})
             name = options[:channel]
-            limit = options.fetch(:id_limit, Slack::Web.config.conversations_id_page_size)
-            types = options.fetch(:id_types, nil)
-
             raise ArgumentError, 'Required arguments :channel missing' if name.nil?
 
             id_for(
@@ -30,7 +32,12 @@ module Slack
               prefix: '#',
               enum_method: :conversations_list,
               list_method: :channels,
-              options: { limit: limit, types: types }.compact
+              options: {
+                team_id: options.fetch(:team_id, nil),
+                exclude_archived: options.fetch(:id_exclude_archived, nil),
+                limit: options.fetch(:id_limit, Slack::Web.config.conversations_id_page_size),
+                types: options.fetch(:id_types, nil)
+              }.compact
             )
           end
         end

--- a/lib/slack/web/api/mixins/users.id.rb
+++ b/lib/slack/web/api/mixins/users.id.rb
@@ -12,12 +12,13 @@ module Slack
           #
           # @option options [user] :user
           #   User to get ID for, prefixed with '@'.
+          # @option options [string] :team_id
+          #   The team id to search for users in, required if token belongs to org-wide app.
+          #   This field will be ignored if the API call is sent using a workspace-level token.
           # @option options [integer] :id_limit
           #   The page size used for users_list calls required to find the user's ID
           def users_id(options = {})
             name = options[:user]
-            limit = options.fetch(:id_limit, Slack::Web.config.users_id_page_size)
-
             raise ArgumentError, 'Required arguments :user missing' if name.nil?
 
             id_for(
@@ -26,7 +27,10 @@ module Slack
               prefix: '@',
               enum_method: :users_list,
               list_method: :members,
-              options: { limit: limit }.compact
+              options: {
+                team_id: options.fetch(:team_id, nil),
+                limit: options.fetch(:id_limit, Slack::Web.config.users_id_page_size)
+              }.compact
             )
           end
         end

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
       )
     end
 
+    it 'forwards a provided team_id to the underlying conversations_list calls' do
+      expect(conversations).to receive(:conversations_list).with(team_id: 'T1234567890')
+      conversations.conversations_id(channel: '#general', team_id: 'T1234567890')
+    end
+
+    it 'forwards a provided exclude_archived to the underlying conversations_list calls' do
+      expect(conversations).to receive(:conversations_list).with(exclude_archived: true)
+      conversations.conversations_id(channel: '#general', id_exclude_archived: true)
+    end
+
     it 'forwards the provided limit to the underlying conversations_list calls' do
       expect(conversations).to receive(:conversations_list).with(limit: 1234)
       conversations.conversations_id(channel: '#general', id_limit: 1234)

--- a/spec/slack/web/api/mixins/users_spec.rb
+++ b/spec/slack/web/api/mixins/users_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
       expect(users.users_id(user: '@aws')).to eq('ok' => true, 'user' => { 'id' => 'UDEADBEEF' })
     end
 
+    it 'forwards a provided team_id to the underlying users_list calls' do
+      expect(users).to receive(:users_list).with(team_id: 'T1234567890')
+      users.users_id(user: '@aws', team_id: 'T1234567890')
+    end
+
     it 'forwards a provided limit to the underlying users_list calls' do
       expect(users).to receive(:users_list).with(limit: 1234)
       users.users_id(user: '@aws', id_limit: 1234)
@@ -45,7 +50,7 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
       )
     end
 
-    context 'when a non-default conversations_id page size has been configured' do
+    context 'when a non-default users_id page size has been configured' do
       before { Slack::Web.config.users_id_page_size = 500 }
 
       after { Slack::Web.config.reset }


### PR DESCRIPTION
Adds the ability to supply all sensible options to the list calls underlying `conversations_id` and `users_id`. A couple considerations were made while creating this code:

- Supplying `users_list` with `include_locale` is useless since we will immediately throw away the added locale data when plucking and returning the user's id. As such, it has been excluded.
- Unlike the other parameters, `team_id` is not prefixed to avoid collision with parameters intended for parent calls (i.e. is not `id_team_id`). In fact, using the same `team_id` with the parent calls seems _desirable_; it means one cannot look up a user in one team and then look up conversations from that user id in another with e.g.

```ruby
client.users_conversations(
  user: "@some-user",
  team_id: "T0123456",
  id_team_id: "T987654"
)
```