### PR TITLE
Raise InvalidSignature if Slack::Events::Request has no signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#554](https://github.com/slack-ruby/slack-ruby-client/pull/557): Require Faraday >= 2.0.1 - [@anrichvs](https://github.com/AnrichVS).
 * [#559](https://github.com/slack-ruby/slack-ruby-client/pull/559): Enable name-to-id translation of non-public channels - [@eizengan](https://github.com/eizengan).
 * [#560](https://github.com/slack-ruby/slack-ruby-client/pull/560): Name-to-id translation can supply all sensible list options - [@eizengan](https://github.com/eizengan).
+* [#561](https://github.com/slack-ruby/slack-ruby-client/issues/563): Raise InvalidSignature when verifying a request without a signature - [@wesleyjellis](https://github.com/wesleyjellis).
 * Your contribution here.
 
 ### 2.6.0 (2025/05/24)

--- a/lib/slack/events/request.rb
+++ b/lib/slack/events/request.rb
@@ -55,6 +55,7 @@ module Slack
       # Returns true if the signature coming from Slack is valid.
       def valid?
         raise MissingSigningSecret unless signing_secret
+        raise InvalidSignature unless signature
 
         digest = OpenSSL::Digest.new('SHA256')
         signature_basestring = [version, timestamp, body].join(':')

--- a/spec/slack/events/request_spec.rb
+++ b/spec/slack/events/request_spec.rb
@@ -47,6 +47,18 @@ RSpec.describe Slack::Events::Request do
     expect(http_request.body.read).to eq body
   end
 
+  context 'missing signature' do
+    subject(:request) do
+      described_class.new(http_request)
+    end
+
+    let(:signature) { nil }
+
+    it 'raises InvalidSignature' do
+      expect { request.valid? }.to raise_error Slack::Events::Request::InvalidSignature
+    end
+  end
+
   context 'with an already read body' do
     before do
       http_request.body.read


### PR DESCRIPTION
Fix regression after #553. The old implementation handled a nil value properly, but the new implementation raises as `nil` does not have `bytesize`

Closes #563 

(Will fix the changelog in a second)