### PR TITLE
Redact Authorization header in response stored in the error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### 2.7.1 (Next)
 
+* [#568](https://github.com/slack-ruby/slack-ruby-client/pull/568): Redact Authorization header in response stored in the error - [@levenleven](https://github.com/levenleven).
+
 * Your contribution here.
 
 ### 2.7.0 (2025/07/20)


### PR DESCRIPTION
`SlackError` contains `env.response`, including request headers and `SLACK_API_TOKEN` which can be accidentally leaked by logging the error.

This PR redacts `Authorization` header before storing the response object in the error.

Resolves https://github.com/slack-ruby/slack-ruby-client/issues/552