### PR TITLE
WIP: upgrade async-websocket.

### DIFF
--- a/examples/hi_real_time_async_async/Gemfile
+++ b/examples/hi_real_time_async_async/Gemfile
@@ -3,5 +3,6 @@ source 'http://rubygems.org'
 
 gem 'slack-ruby-client', path: '../..'
 
-gem 'async-websocket'
+gem 'async-websocket', '> 0.9'
+gem 'io-endpoint'
 gem 'foreman'


### PR DESCRIPTION
Started on https://github.com/slack-ruby/slack-ruby-client/issues/282, but probably not worth it since slack deprecated RTM APIs. Should rip RTM support out.