### PR TITLE
Not found errors raised by id_for use more specific error classes when they exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 3.1.1 (Next)
+### 3.2.0 (Next)
 
 * [#581](https://github.com/slack-ruby/slack-ruby-client/pull/581): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
 * [#583](https://github.com/slack-ruby/slack-ruby-client/pull/583): Not found errors raised by id_for use more specific error classes when they exist - [@eizengan](https://github.com/eizengan).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.1.1 (Next)
 
 * [#581](https://github.com/slack-ruby/slack-ruby-client/pull/581): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
+* [#583](https://github.com/slack-ruby/slack-ruby-client/pull/583): Not found errors raised by id_for use more specific error classes when they exist - [@eizengan](https://github.com/eizengan).
 * Your contribution here.
 
 ### 3.1.0 (2025/11/15)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,10 @@
 Upgrading Slack-Ruby-Client
 ===========================
 
+### Upgrading to >= 3.2.0
+
+[#583](https://github.com/slack-ruby/slack-ruby-client/pull/583) modifies the error types raised when a nonexistent #channel-name or @user-handle is looked up. These will now raise `ChannelNotFound` and `UserNotFound` respectively, whereas they previously raised a `SlackError`. If your code relies on these types without accounting for inheritance, it will need to be migrated. Notably, `rescue SlackError` will continue to work as normal, since both error classes inherit from it.
+
 ### Upgrading to >= 3.0.0
 
 Support for the [RTM API](https://docs.slack.dev/tools/java-slack-sdk/guides/rtm/) has been removed in [#573](https://github.com/slack-ruby/slack-ruby-client/pull/573). By now you should have [migrated your app to granular permissions](https://code.dblock.org/2020/11/30/migrating-classic-slack-ruby-bots-to-granular-permissions.html), and you should lock your slack-ruby-client to 2.x for those bots. Next, to remove RTM components we found it more effective to just [write a new version of a bot](https://code.dblock.org/2024/06/30/writing-a-channel-slack-bot.html) and avoid a complex migration.

--- a/lib/slack/version.rb
+++ b/lib/slack/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Slack
-  VERSION = '3.1.1'
+  VERSION = '3.2.0'
 end

--- a/lib/slack/web/api/mixins/ids.id.rb
+++ b/lib/slack/web/api/mixins/ids.id.rb
@@ -15,7 +15,9 @@ module Slack
               end
             end
 
-            raise Slack::Web::Api::Errors::SlackError, "#{key}_not_found"
+            error_message = "#{key}_not_found"
+            error_class = Slack::Web::Api::Errors::ERROR_CLASSES[error_message] || Slack::Web::Api::Errors::SlackError
+            raise error_class, error_message
           end
         end
       end

--- a/spec/slack/web/api/mixins/conversations_spec.rb
+++ b/spec/slack/web/api/mixins/conversations_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Slack::Web::Api::Mixins::Conversations do
 
     it 'fails with an exception' do
       expect { conversations.conversations_id(channel: '#invalid') }.to(
-        raise_error(Slack::Web::Api::Errors::SlackError, 'channel_not_found')
+        raise_error(Slack::Web::Api::Errors::ChannelNotFound, 'channel_not_found')
       )
     end
 

--- a/spec/slack/web/api/mixins/users_spec.rb
+++ b/spec/slack/web/api/mixins/users_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Slack::Web::Api::Mixins::Users do
 
     it 'fails with an exception' do
       expect { users.users_id(user: '@foo') }.to(
-        raise_error(Slack::Web::Api::Errors::SlackError, 'user_not_found')
+        raise_error(Slack::Web::Api::Errors::UserNotFound, 'user_not_found')
       )
     end
 


### PR DESCRIPTION
### Problem

Presently the `id_for` method always raises a `SlackError`. This means that when calling e.g. `users_info` one must handle both `UserNotFound` and `SlackError`-with-a-message-equal-"user_not_found" to actually cover ones bases. 

### Solution

This uses the existing error type deduction mechanism to raise a more specific error when one exists. At the time of writing this will work for all consumers of `id_for`

### Potential issues

The specific errors are subclasses of `SlackError`, and therefore will still behave as expected in existing `rescue`s, `is_a?` calls, etc. Any class equality checks failing to account for inheritance, however, will break.