### PR TITLE
Fix Ruby-version-dependent hash literal syntax in generated specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#583](https://github.com/slack-ruby/slack-ruby-client/pull/583): Not found errors raised by id_for use more specific error classes when they exist - [@eizengan](https://github.com/eizengan).
 * [#585](https://github.com/slack-ruby/slack-ruby-client/pull/585): Fix ci not triggering on automated api update prs - [@Copilot](https://github.com/Copilot).
 * [#588](https://github.com/slack-ruby/slack-ruby-client/pull/588): Fix text/markdown_text mutual exclusion in chat methods - [@dblock](https://github.com/dblock).
+* [#589](https://github.com/slack-ruby/slack-ruby-client/pull/589): Fix Ruby-version-dependent hash literal syntax in generated specs - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.1.0 (2025/11/15)

--- a/lib/slack/web/api/templates/method_spec.erb
+++ b/lib/slack/web/api/templates/method_spec.erb
@@ -5,6 +5,21 @@ require 'spec_helper'
 
 RSpec.describe Slack::Web::Api::Endpoints::<%= group.gsub(".", "_").camelize %> do
   let(:client) { Slack::Web::Client.new }
+<%
+  # Renders a Ruby literal as source code deterministically, regardless of the
+  # Ruby version used to run the generator (Hash#inspect's format for symbol
+  # keys changed in Ruby 3.4, which would otherwise cause spurious diffs).
+  ruby_literal = lambda do |val|
+    case val
+    when Hash
+      "{#{val.map { |k, v| "#{k}: #{ruby_literal.call(v)}" }.join(', ')}}"
+    when Array
+      "[#{val.map { |v| ruby_literal.call(v) }.join(', ')}]"
+    else
+      val.inspect
+    end
+  end
+%>
 <% names.sort.each_with_index do |(name, data), index| %>
 <% next if data['mixin'] %>
 <% group_required_params = data['arg_groups']&.map { |grp| grp['args'].first if grp['args'].size > 1 } || [] %>
@@ -59,7 +74,7 @@ RSpec.describe Slack::Web::Api::Endpoints::<%= group.gsub(".", "_").camelize %> 
 <% end %>
 <% if json_params.any? %>
 <% example_json_params = json_params.to_h { |name| [name, {data: ['data']}] } %>
-<% params = example_params.merge(example_json_params).map { |name, val| val = val.is_a?(String) ? "%q[#{val}]" : val; "#{name}: #{val}" }.join(', ') %>
+<% params = example_params.merge(example_json_params).map { |name, val| val = val.is_a?(String) ? "%q[#{val}]" : ruby_literal.call(val); "#{name}: #{val}" }.join(', ') %>
 <% expected_params = example_params.merge(example_json_params.transform_values { |v| JSON.dump(v) }).map { |name, val| val = "%q[#{val}]"; "#{name}: #{val}" }.join(', ') %>
     it 'encodes <%= json_params.join(', ') %> as json' do
       expect(client).to receive(:post).with('<%= group %>.<%= name %>', {<%= expected_params %>})


### PR DESCRIPTION
### Problem

The scheduled automated API update workflow (PR #578 being an example) occasionally produced spurious diffs flipping hash literal syntax back and forth between:

```ruby
{data: ["data"]}
```

and

```ruby
{:data=>["data"]}
```

### Root cause

Ruby 3.4 changed `Hash#inspect`'s default rendering of symbol keys from the hash-rocket form (`:foo=>1`) to the modern shorthand (`foo: 1`). `lib/slack/web/api/templates/method_spec.erb` relied on implicit string interpolation of a real `Hash` object (`#{val}`) when building the "encodes ... as json" test's params, so the literal syntax emitted into generated spec files depended on whichever Ruby version ran the generator. `.github/workflows/update_api.yml`'s scheduled job pins Ruby 3.2, while a contributor running the rake task locally may have a newer Ruby, so regenerated PRs would alternate style depending on who/what last ran it.

### Fix

Add a `ruby_literal` helper to `method_spec.erb` that explicitly renders `Hash`/`Array` values as source text using the modern `key: value` syntax (valid since Ruby 1.9, well within this gem's supported Ruby 2.7+ range) instead of relying on `Hash#inspect`. This makes generated output deterministic and independent of the Ruby version used to run `rake slack:web:api:update`.

Verified by regenerating all endpoints/specs/commands with this template change: only the fix itself changed (no other endpoint or spec file differs), confirming the current `master` content already matches this deterministic format and future regenerations will no longer drift.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>