### PR TITLE
Fix YAML indentation bug in AI prompt template substitution

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Prepare diff for AI summary
         if: steps.changes.outputs.changed == 'true'
         run: |
-          git diff --stat > /tmp/diff_stat.txt
-          git diff | head -c 20000 > /tmp/diff.txt
+          git diff --stat | sed 's/^/      /' > /tmp/diff_stat.txt
+          git diff | head -c 20000 | sed 's/^/      /' > /tmp/diff.txt
       - name: Generate changelog entries with AI
         if: steps.changes.outputs.changed == 'true'
         id: ai

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.2.1 (Next)
 
 * [#591](https://github.com/slack-ruby/slack-ruby-client/pull/591): Generate AI CHANGELOG entries and PR summaries for automated API update PRs, lock simplecov below 1.1.0 to avoid breaking Coveralls - [@dblock](https://github.com/dblock).
+* [#592](https://github.com/slack-ruby/slack-ruby-client/pull/592): Fix a YAML indentation bug in AI CHANGELOG entry generation that broke the automated API update workflow - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.2.0 (2026/07/05)


### PR DESCRIPTION
## Problem

The `update_api.yml` workflow's new AI CHANGELOG generation step ([#591](https://github.com/slack-ruby/slack-ruby-client/pull/591)) fails on the first real scheduled run:

```
Generate changelog entries with AI	Using prompt YAML file format
Generate changelog entries with AI	##[error]Failed to parse prompt file: bad indentation of a mapping entry (29:2)
```

https://github.com/slack-ruby/slack-ruby-client/actions/runs/31552877245/job/93979138338

## Root cause

`actions/ai-inference@v1` substitutes `{{diff_stat}}`/`{{diff}}` placeholders as **raw text** into the prompt YAML file *before* parsing it as YAML. The diff/diff-stat files were written starting at column 0, so injecting their multi-line content broke the indentation of the enclosing `content: |-` block scalar in `changelog-entries.prompt.yml`.

## Fix

Pipe the diff/diff-stat output through `sed 's/^/      /'` (6 spaces, matching the prompt file's block scalar indentation) before writing them to the files consumed via `file_input`, so the substituted content stays inside the block and parses correctly.

Verified by simulating the exact template substitution locally with `yaml.safe_load` after applying the fix.
