### PR TITLE
Migrate AI CHANGELOG entry generation to Copilot CLI

### DIFF
--- a/.github/prompts/changelog-entries.prompt.yml
+++ b/.github/prompts/changelog-entries.prompt.yml
@@ -6,7 +6,8 @@ messages:
       are code-generated from JSON method definitions vendored from
       https://github.com/slack-ruby/slack-api-ref (via a git submodule and rake task).
 
-      Given a diffstat and a diff of the regenerated files, respond with a JSON object:
+      Given a diffstat and a diff of the regenerated files, respond with ONLY a single JSON
+      object (no markdown code fences, no other text) in exactly this shape:
       {"entries": [string, ...]}
 
       Rules for entries:
@@ -29,24 +30,3 @@ messages:
 
       Diff (may be truncated):
       {{diff}}
-model: openai/gpt-4o-mini
-responseFormat: json_schema
-jsonSchema: |-
-  {
-    "name": "changelog_entries",
-    "strict": true,
-    "schema": {
-      "type": "object",
-      "properties": {
-        "entries": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "1-8 short, imperative-mood CHANGELOG entry descriptions, no leading bullet or trailing period"
-        }
-      },
-      "additionalProperties": false,
-      "required": ["entries"]
-    }
-  }

--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -10,7 +10,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      models: read
     steps:
       - uses: actions/checkout@v7
         with:
@@ -46,21 +45,30 @@ jobs:
         run: |
           git diff --stat | sed 's/^/      /' > /tmp/diff_stat.txt
           git diff | head -c 20000 | sed 's/^/      /' > /tmp/diff.txt
+      - name: Set up Node
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+      - name: Install Copilot CLI
+        if: steps.changes.outputs.changed == 'true'
+        run: npm install -g @github/copilot
       - name: Generate changelog entries with AI
         if: steps.changes.outputs.changed == 'true'
         id: ai
-        uses: actions/ai-inference@v1
+        uses: actions/ai-inference@v3
         with:
           prompt-file: ./.github/prompts/changelog-entries.prompt.yml
+          model: ''
           file_input: |
             diff_stat: /tmp/diff_stat.txt
             diff: /tmp/diff.txt
+        env:
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT }}
       - name: Build changelog entries
         id: entries
         run: |
           entries=""
           if [ "${{ steps.changes.outputs.changed }}" = "true" ]; then
-            entries="$(jq -r '.entries[]? // empty' "${{ steps.ai.outputs.response-file }}" 2>/dev/null)"
+            entries="$(grep -v '^```' "${{ steps.ai.outputs.response-file }}" 2>/dev/null | jq -r '.entries[]? // empty' 2>/dev/null)"
           fi
           if [ -z "$entries" ]; then
             entries="Update API from slack-api-ref@${{ steps.api-ref.outputs.api-ref }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#591](https://github.com/slack-ruby/slack-ruby-client/pull/591): Generate AI CHANGELOG entries and PR summaries for automated API update PRs, lock simplecov below 1.1.0 to avoid breaking Coveralls - [@dblock](https://github.com/dblock).
 * [#592](https://github.com/slack-ruby/slack-ruby-client/pull/592): Fix a YAML indentation bug in AI CHANGELOG entry generation that broke the automated API update workflow - [@dblock](https://github.com/dblock).
+* [#593](https://github.com/slack-ruby/slack-ruby-client/pull/593): Migrate AI CHANGELOG entry generation to Copilot CLI after GitHub Models retirement - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 ### 3.2.0 (2026/07/05)


### PR DESCRIPTION
## Problem

GitHub Models (`models.github.ai`, the backend `actions/ai-inference@v1` used for AI CHANGELOG entries in [#591](https://github.com/slack-ruby/slack-ruby-client/pull/591)) was **fully retired on July 30, 2026**:

```
Error: 410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout.
```

This is permanent, not a temporary outage — every scheduled `update_api.yml` run will fail from now on.

## Fix

`actions/ai-inference` was rewritten (v3, released July 29, 2026) to exclusively shell out to the **GitHub Copilot CLI** instead of calling GitHub Models. This PR updates the workflow accordingly, mirroring the equivalent fix in [slack-ruby/slack-api-ref#89](https://github.com/slack-ruby/slack-api-ref/pull/89):

- Installs and authenticates the Copilot CLI (`npm install -g @github/copilot`) before invoking `actions/ai-inference@v1`, using `COPILOT_GITHUB_TOKEN` sourced from a new `COPILOT_PAT` repo secret.
- Drops the now-unnecessary `models: read` permission.
- The v3 action also dropped structured JSON schema output (`responseFormat`/`jsonSchema`), so the prompt now asks for a bare JSON object with no markdown fences, and the "Build changelog entries" step strips any ` ``` ` fences defensively before parsing with `jq`.

## ⚠️ Action required

This requires adding a **`COPILOT_PAT`** secret (a PAT for an account with Copilot CLI access) to this repository's Actions secrets for the workflow to actually run. Copilot CLI usage is free for individual accounts (with monthly limits) and open source maintainers can request higher/unlimited access — see https://github.com/features/copilot/plans.
