### PR TITLE
Include AI-generated changelog entries in the commit message

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -96,7 +96,10 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.github_app_token.outputs.token || secrets.GITHUB_TOKEN }}
-          commit-message: Update API from slack-api-ref@${{ steps.api-ref.outputs.api-ref }} (${{ steps.date.outputs.date }})
+          commit-message: |
+            Update API from slack-api-ref@${{ steps.api-ref.outputs.api-ref }} (${{ steps.date.outputs.date }})
+
+            ${{ steps.entries.outputs.body_list }}
           title: Update API from slack-api-ref@${{ steps.api-ref.outputs.api-ref }}
           body: |
             Update API from [slack-api-ref](https://github.com/slack-ruby/slack-api-ref).


### PR DESCRIPTION
PR #590 showed a gap: the automated API update commit message was just `Update API from slack-api-ref@784d1d4 (2026-08-12)`, with no details, while the PR body had the full AI-generated list of changes.

This reuses `steps.entries.outputs.body_list` (already computed for the PR body) in `commit-message` as well, so the commit message itself carries the same bulleted summary — useful for anyone looking at `git log`/`git blame` outside the PR UI.