### PR TITLE
Fix update_api workflow failing on non-JSON AI changelog response

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -68,7 +68,11 @@ jobs:
         run: |
           entries=""
           if [ "${{ steps.changes.outputs.changed }}" = "true" ]; then
-            entries="$(grep -v '^```' "${{ steps.ai.outputs.response-file }}" 2>/dev/null | jq -r '.entries[]? // empty' 2>/dev/null)"
+            response_file="${{ steps.ai.outputs.response-file }}"
+            echo "AI changelog response:"
+            cat "$response_file" || true
+            filtered="$(grep -v '^```' "$response_file" 2>/dev/null)"
+            entries="$(printf '%s' "$filtered" | jq -r '.entries[]? // empty' 2>/dev/null || true)"
           fi
           if [ -z "$entries" ]; then
             entries="Update API from slack-api-ref@${{ steps.api-ref.outputs.api-ref }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#591](https://github.com/slack-ruby/slack-ruby-client/pull/591): Generate AI CHANGELOG entries and PR summaries for automated API update PRs, lock simplecov below 1.1.0 to avoid breaking Coveralls - [@dblock](https://github.com/dblock).
 * [#592](https://github.com/slack-ruby/slack-ruby-client/pull/592): Fix a YAML indentation bug in AI CHANGELOG entry generation that broke the automated API update workflow - [@dblock](https://github.com/dblock).
 * [#593](https://github.com/slack-ruby/slack-ruby-client/pull/593): Migrate AI CHANGELOG entry generation to Copilot CLI after GitHub Models retirement - [@dblock](https://github.com/dblock).
+* [#596](https://github.com/slack-ruby/slack-ruby-client/pull/596): Fix the `update_api` workflow failing with exit code 5 when the AI-generated changelog response isn't valid JSON, and always log the raw AI response for debugging - [@dblock](https://github.com/dblock).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add entity.acknowledgeCommentAction and entity.presentComments methods - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add admin.apps.mcpServers, admin.apps.mcpServers.permissions, and admin.apps.permissions endpoints - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add a metadata argument to chat.postEphemeral - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).


### PR DESCRIPTION
## Problem

The scheduled `Update API` workflow run [32789898905](https://github.com/slack-ruby/slack-ruby-client/actions/runs/32789898905/job/97629221516) failed at the "Build changelog entries" step with exit code 5.

The step runs under `bash -e` (GitHub Actions default). When the AI-generated changelog response isn't valid JSON, `jq` exits with status 5, which aborts the whole step instead of falling back to the default `Update API from slack-api-ref@...` entry.

## Fix

* Guards the `jq` invocation so a non-zero exit doesn't kill the step; falls back to the default entry as originally intended.
* Always logs the raw AI response for easier debugging of future generation issues.