### PR TITLE
Extract JSON from Copilot CLI response despite narration, fail visibly when missing

### DIFF
--- a/.github/workflows/update_api.yml
+++ b/.github/workflows/update_api.yml
@@ -71,8 +71,15 @@ jobs:
             response_file="${{ steps.ai.outputs.response-file }}"
             echo "AI changelog response:"
             cat "$response_file" || true
-            filtered="$(grep -v '^```' "$response_file" 2>/dev/null)"
-            entries="$(printf '%s' "$filtered" | jq -r '.entries[]? // empty' 2>/dev/null || true)"
+            # Copilot CLI's response file may include narration/thinking lines
+            # before the final JSON answer, so grab the last line that looks
+            # like a JSON object rather than trying to parse the whole file.
+            json_line="$(grep -E '^\{.*\}$' "$response_file" 2>/dev/null | tail -n 1)"
+            if [ -z "$json_line" ]; then
+              echo "::error::AI changelog response did not contain a JSON object, see response above."
+              exit 1
+            fi
+            entries="$(printf '%s' "$json_line" | jq -r '.entries[]? // empty')"
           fi
           if [ -z "$entries" ]; then
             entries="Update API from slack-api-ref@${{ steps.api-ref.outputs.api-ref }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 ### 3.2.1 (Next)
 
 * [#591](https://github.com/slack-ruby/slack-ruby-client/pull/591): Generate AI CHANGELOG entries and PR summaries for automated API update PRs, lock simplecov below 1.1.0 to avoid breaking Coveralls - [@dblock](https://github.com/dblock).
-* [#592](https://github.com/slack-ruby/slack-ruby-client/pull/592): Fix a YAML indentation bug in AI CHANGELOG entry generation that broke the automated API update workflow - [@dblock](https://github.com/dblock).
-* [#593](https://github.com/slack-ruby/slack-ruby-client/pull/593): Migrate AI CHANGELOG entry generation to Copilot CLI after GitHub Models retirement - [@dblock](https://github.com/dblock).
-* [#596](https://github.com/slack-ruby/slack-ruby-client/pull/596): Fix the `update_api` workflow failing with exit code 5 when the AI-generated changelog response isn't valid JSON, and always log the raw AI response for debugging - [@dblock](https://github.com/dblock).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add entity.acknowledgeCommentAction and entity.presentComments methods - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add admin.apps.mcpServers, admin.apps.mcpServers.permissions, and admin.apps.permissions endpoints - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add a metadata argument to chat.postEphemeral - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).


### PR DESCRIPTION
## Problem

PR #596 fixed the workflow crashing on non-JSON AI responses, but as a side effect it also silently discarded **valid** AI-generated changelog entries whenever Copilot CLI's response included narration/thinking text before its final JSON answer.

This is exactly what happened in run [32801440182](https://github.com/slack-ruby/slack-ruby-client/actions/runs/32801440182/job/97662921005): the workflow succeeded, but fell back to the generic "Update API from slack-api-ref@..." entry even though the AI had produced a correct, detailed `{"entries": [...]}` JSON object — it was just preceded by several lines of Copilot CLI narration ("Let me inspect the actual diffs...", etc).

## Fix

* Extract the **last line** that looks like a JSON object (`^\{.*\}$`) from the response file, rather than trying to parse the whole file. Copilot CLI puts its final answer as the last line.
* If no such line is found at all, fail the step visibly with `::error::` instead of silently falling back to the generic entry, so a genuinely broken AI response is caught rather than masked.

Verified against the actual response text captured from the failing run, good/invalid synthetic responses, and confirmed correct entries are now extracted in all cases.