### PR TITLE
Set a default filename so that Slack displays the file preview correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 3.2.1 (Next)
 
+* [#375](https://github.com/slack-ruby/slack-ruby-client/pull/375): Set a default filename in `files_upload` so Slack displays image previews correctly when none is specified - [@ts-3156](https://github.com/ts-3156), [@dblock](https://github.com/dblock).
 * [#591](https://github.com/slack-ruby/slack-ruby-client/pull/591): Generate AI CHANGELOG entries and PR summaries for automated API update PRs, lock simplecov below 1.1.0 to avoid breaking Coveralls - [@dblock](https://github.com/dblock).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add entity.acknowledgeCommentAction and entity.presentComments methods - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).
 * [#590](https://github.com/slack-ruby/slack-ruby-client/pull/590): Add admin.apps.mcpServers, admin.apps.mcpServers.permissions, and admin.apps.permissions endpoints - [@slack-ruby-ci-bot](https://github.com/apps/slack-ruby-ci-bot).

--- a/lib/slack/web/api/endpoints/files.rb
+++ b/lib/slack/web/api/endpoints/files.rb
@@ -192,6 +192,7 @@ module Slack
           # @see https://api.slack.com/methods/files.upload
           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.upload.json
           def files_upload(options = {})
+            options = options.merge(filename: 'file') if options[:file] && !options[:filename]
             post('files.upload', options)
           end
         end

--- a/lib/slack/web/api/patches/files.default-filename.patch
+++ b/lib/slack/web/api/patches/files.default-filename.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/slack/web/api/endpoints/files.rb b/lib/slack/web/api/endpoints/files.rb
+index 13a1889..9ce4894 100644
+--- a/lib/slack/web/api/endpoints/files.rb
++++ b/lib/slack/web/api/endpoints/files.rb
+@@ -192,6 +192,7 @@ module Slack
+           # @see https://api.slack.com/methods/files.upload
+           # @see https://github.com/slack-ruby/slack-api-ref/blob/master/methods/files/files.upload.json
+           def files_upload(options = {})
++            options = options.merge(filename: 'file') if options[:file] && !options[:filename]
+             post('files.upload', options)
+           end
+         end


### PR DESCRIPTION
Finishes #375 as a patch.

Since 2021/05/05, Slack no longer correctly displays image previews for files uploaded via `files_upload` when no filename is specified. `Faraday::UploadIO`/multipart-post falls back to the local IO path as the filename in that case, and Slack treats the file as binary if the filename looks like a path.

This sets a default filename of `'file'` when `:file` is present but `:filename` is not, matching the fix originally proposed in #375 by @ts-3156.

Closes #375.